### PR TITLE
help make jparse independent of dbg and dyn_array repos

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -27,7 +27,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/jparse_main.h
+++ b/jparse_main.h
@@ -25,7 +25,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/jsemtblgen.h
+++ b/jsemtblgen.h
@@ -31,7 +31,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit
@@ -41,7 +45,11 @@
 /*
  * dyn_array - dynamic array facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dyn_array/dyn_array.h"
+#else
+#include <dyn_array.h>
+#endif
 
 /*
  * json_util - general JSON parser utility support functions
@@ -57,11 +65,6 @@
  * json_sem - JSON semantics support
  */
 #include "json_sem.h"
-
-/*
- * iocccsize - IOCCC Source Size Tool
- */
-#include "../iocccsize.h"
 
 /*
  * official jsemtblgen version

--- a/json_parse.c
+++ b/json_parse.c
@@ -34,7 +34,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/json_sem.c
+++ b/json_sem.c
@@ -32,7 +32,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * json_sem - JSON semantics support

--- a/json_util.c
+++ b/json_util.c
@@ -30,7 +30,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * json_parse - JSON parser support code

--- a/json_util.h
+++ b/json_util.h
@@ -25,7 +25,11 @@
 /*
  * dyn_array - dynamic array facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dyn_array/dyn_array.h"
+#else
+#include <dyn_array.h>
+#endif
 
 /*
  * util - utilities and macros

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -25,7 +25,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -25,7 +25,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/test_jparse/jnum_chk.h
+++ b/test_jparse/jnum_chk.h
@@ -25,7 +25,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/test_jparse/jnum_gen.h
+++ b/test_jparse/jnum_gen.h
@@ -25,7 +25,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit
@@ -45,7 +49,11 @@
 /*
  * dyn_array - dynamic array facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../../dyn_array/dyn_array.h"
+#else
+#include <dyn_array.h>
+#endif
 
 
 

--- a/util.c
+++ b/util.c
@@ -49,7 +49,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit

--- a/util.h
+++ b/util.h
@@ -66,7 +66,11 @@ typedef unsigned char bool;
 /*
  * dyn_array - dynamic array facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dyn_array/dyn_array.h"
+#else
+#include <dyn_array.h>
+#endif
 
 
 /*

--- a/verge.h
+++ b/verge.h
@@ -25,7 +25,11 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
+#if defined(MKIOCCCENTRY_SRC)
 #include "../dbg/dbg.h"
+#else
+#include <dbg.h>
+#endif
 
 /*
  * util - common utility functions for the IOCCC toolkit


### PR DESCRIPTION
We use `#if defined(MKIOCCCENTRY_SRC)` to determine of we are in a case where the `dbg/` and `dyn_array/` trees are under the same parent source tree, or if they are assumed have their include files installed.

This requires one to update and re-install from the [dyn_array repo](https://github.com/lcn2/dyn_array).