### PR TITLE
rename MKIOCCCENTRY_SRC to INTERNAL_INCLUDE

### DIFF
--- a/jparse.h
+++ b/jparse.h
@@ -27,7 +27,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/jparse_main.h
+++ b/jparse_main.h
@@ -25,7 +25,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/jsemtblgen.h
+++ b/jsemtblgen.h
@@ -31,7 +31,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>
@@ -45,7 +45,7 @@
 /*
  * dyn_array - dynamic array facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dyn_array/dyn_array.h"
 #else
 #include <dyn_array.h>

--- a/json_parse.c
+++ b/json_parse.c
@@ -34,7 +34,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/json_sem.c
+++ b/json_sem.c
@@ -32,7 +32,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/json_util.c
+++ b/json_util.c
@@ -30,7 +30,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/json_util.h
+++ b/json_util.h
@@ -25,7 +25,7 @@
 /*
  * dyn_array - dynamic array facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dyn_array/dyn_array.h"
 #else
 #include <dyn_array.h>

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -25,7 +25,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -25,7 +25,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/test_jparse/jnum_chk.h
+++ b/test_jparse/jnum_chk.h
@@ -25,7 +25,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/test_jparse/jnum_gen.h
+++ b/test_jparse/jnum_gen.h
@@ -25,7 +25,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../../dbg/dbg.h"
 #else
 #include <dbg.h>
@@ -49,7 +49,7 @@
 /*
  * dyn_array - dynamic array facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../../dyn_array/dyn_array.h"
 #else
 #include <dyn_array.h>

--- a/util.c
+++ b/util.c
@@ -49,7 +49,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>

--- a/util.h
+++ b/util.h
@@ -66,7 +66,7 @@ typedef unsigned char bool;
 /*
  * dyn_array - dynamic array facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dyn_array/dyn_array.h"
 #else
 #include <dyn_array.h>

--- a/verge.h
+++ b/verge.h
@@ -25,7 +25,7 @@
 /*
  * dbg - info, debug, warning, error, and usage message facility
  */
-#if defined(MKIOCCCENTRY_SRC)
+#if defined(INTERNAL_INCLUDE)
 #include "../dbg/dbg.h"
 #else
 #include <dbg.h>


### PR DESCRIPTION
We used:

```sh
sgit -e 's/MKIOCCCENTRY_SRC/INTERNAL_INCLUDE/g' *
```

to rename the `MKIOCCCENTRY_SRC` CPP symbol to
a more generic `INTERNAL_INCLUDE` CPP symbol.

This change is in sync with a recent change to
the dyn_array repo, and will be coordinated
with pending change to the mkiocccentry repo soon.