### PR TITLE
remove dependency on dbg and dyn_array locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,19 +435,19 @@ jparse.o: jparse.c jparse.h
 	${CC} ${CFLAGS} jparse.c -c
 
 jparse: jparse_main.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 jstrencode.o: jstrencode.c jstrencode.h json_util.h json_util.c
 	${CC} ${CFLAGS} jstrencode.c -c
 
 jstrencode: jstrencode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 jstrdecode.o: jstrdecode.c jstrdecode.h json_util.h json_parse.h
 	${CC} ${CFLAGS} jstrdecode.c -c
 
 jstrdecode: jstrdecode.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 json_parse.o: json_parse.c
 	${CC} ${CFLAGS} json_parse.c -c
@@ -456,7 +456,7 @@ jsemtblgen.o: jsemtblgen.c jparse.tab.h
 	${CC} ${CFLAGS} jsemtblgen.c -c
 
 jsemtblgen: jsemtblgen.o libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldbg -ldyn_array
 
 json_sem.o: json_sem.c
 	${CC} ${CFLAGS} json_sem.c -c
@@ -495,7 +495,7 @@ verge.o: verge.c verge.h
 	${CC} ${CFLAGS} verge.c -c
 
 verge: verge.o util.o
-	${CC} ${CFLAGS} $^ -o $@ -L../dbg -L../dyn_array -ldbg -ldyn_array
+	${CC} ${CFLAGS} $^ -o $@ -ldbg -ldyn_array
 
 libjparse.a: ${LIB_OBJS}
 	${RM} -f $@
@@ -964,7 +964,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	    ${SED} -i.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
-	      ${SED} -e 's;\.\./dyn_array/\.\./dbg/;../dbg/;g' | \
+	      ${SED} -E -e 's;\s/usr/local/include/\S+;;' -e 's;\s/usr/include/\S+;;' | \
 	      ${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} -f Makefile.orig; \

--- a/Makefile
+++ b/Makefile
@@ -964,7 +964,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	    ${SED} -i.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
-	      ${SED} -E -e 's;\s/usr/local/include/\S+;;' -e 's;\s/usr/include/\S+;;' | \
+	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
 	      ${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} -f Makefile.orig; \

--- a/test_jparse/Makefile
+++ b/test_jparse/Makefile
@@ -317,19 +317,19 @@ jnum_chk.o: jnum_chk.c jnum_chk.h
 	${CC} ${CFLAGS} -I../.. jnum_chk.c -c
 
 jnum_chk: jnum_chk.o jnum_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../../dyn_array -L../../dbg -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldyn_array -ldbg
 
 jnum_gen.o: jnum_gen.c jnum_gen.h
 	${CC} ${CFLAGS} jnum_gen.c -c
 
 jnum_gen: jnum_gen.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -lm -o $@ -L../../dyn_array -L../../dbg -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -lm -o $@ -ldyn_array -ldbg
 
 pr_jparse_test.o: pr_jparse_test.c
 	${CC} ${CFLAGS} pr_jparse_test.c -c
 
 pr_jparse_test: pr_jparse_test.o ../libjparse.a
-	${CC} ${CFLAGS} $^ -o $@ -L../../dyn_array -L../../dbg -ldyn_array -ldbg
+	${CC} ${CFLAGS} $^ -o $@ -ldyn_array -ldbg
 
 
 
@@ -622,9 +622,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	    ${SED} -i\.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
-	      ${SED} -e 's;\.\./\.\./jparse/\.\./dyn_array/;../../dyn_array/;g' \
-	             -e 's;\.\./\.\./dyn_array/\.\./dbg/;../../dbg/;g' \
-	             -e 's;\.\./\.\./jparse/;../;g' | \
+	      ${SED} -E -e 's;\s/usr/local/include/\S+;;' -e 's;\s/usr/include/\S+;;' | \
 	      ${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} -f Makefile.orig; \
@@ -638,10 +636,13 @@ depend: ${ALL_CSRC}
 	${S} echo "${OUR_NAME}: make $@ ending"
 
 ### DO NOT CHANGE MANUALLY BEYOND THIS LINE
-jnum_chk.o: ../json_parse.h ../json_util.h ../util.h jnum_chk.c jnum_chk.h
+jnum_chk.o: ../../jparse/json_parse.h ../../jparse/json_util.h \
+    ../json_parse.h ../util.h jnum_chk.c jnum_chk.h
 jnum_gen.o: ../json_parse.h ../json_util.h ../util.h jnum_gen.c jnum_gen.h
-jnum_header.o: ../json_parse.h ../json_util.h ../util.h jnum_chk.h \
+jnum_header.o: ../../jparse/json_parse.h ../../jparse/json_util.h \
+    ../json_parse.h ../util.h /usr/local/include/dbg.h jnum_chk.h \
     jnum_header.c
-jnum_test.o: ../json_parse.h ../json_util.h ../util.h jnum_chk.h \
+jnum_test.o: ../../jparse/json_parse.h ../../jparse/json_util.h \
+    ../json_parse.h ../util.h /usr/local/include/dbg.h jnum_chk.h \
     jnum_test.c
-pr_jparse_test.o: ../util.h pr_jparse_test.c
+pr_jparse_test.o: ../util.h /usr/local/include/dbg.h pr_jparse_test.c

--- a/test_jparse/Makefile
+++ b/test_jparse/Makefile
@@ -622,7 +622,7 @@ depend: ${ALL_CSRC}
 	    fi; \
 	    ${SED} -i\.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
-	      ${SED} -E -e 's;\s/usr/local/include/\S+;;' -e 's;\s/usr/include/\S+;;' | \
+	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
 	      ${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} -f Makefile.orig; \
@@ -640,9 +640,7 @@ jnum_chk.o: ../../jparse/json_parse.h ../../jparse/json_util.h \
     ../json_parse.h ../util.h jnum_chk.c jnum_chk.h
 jnum_gen.o: ../json_parse.h ../json_util.h ../util.h jnum_gen.c jnum_gen.h
 jnum_header.o: ../../jparse/json_parse.h ../../jparse/json_util.h \
-    ../json_parse.h ../util.h /usr/local/include/dbg.h jnum_chk.h \
-    jnum_header.c
+    ../json_parse.h ../util.h jnum_chk.h jnum_header.c
 jnum_test.o: ../../jparse/json_parse.h ../../jparse/json_util.h \
-    ../json_parse.h ../util.h /usr/local/include/dbg.h jnum_chk.h \
-    jnum_test.c
-pr_jparse_test.o: ../util.h /usr/local/include/dbg.h pr_jparse_test.c
+    ../json_parse.h ../util.h jnum_chk.h jnum_test.c
+pr_jparse_test.o: ../util.h pr_jparse_test.c


### PR DESCRIPTION
We modify the `Makefile` and `test_jparse/Makefile` to not require that dbg nor dyn_array code be located in a parallel directory.

We modify the `make depend` rules to not put any
`/usr/include/` nor `/usr/local/include/` header paths into the dependency rules at the bottom of Makefiles.

Performed `make clobber depend all test` to test the above under macOS.

This code has been tested well under macOS and RHEL9 Linux.

These changes are compatible with the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) when d40f7c7adebb10b8c6a4191f78da54ba2079ae28 is applied to that repo.