### PR TITLE
improve -Q language for jstrdecode and jstrencode

### DIFF
--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -58,7 +58,7 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit\n"
     "\t-t\t\tperform jencchk test on code JSON decode/encode functions\n"
     "\t-n\t\tdo not output newline after decode output\n"
-    "\t-Q\t\tenclose output in quotes (def: do not)\n"
+    "\t-Q\t\tenclose output in double quotes (def: do not)\n"
     "\t-e\t\tenclose each decoded string with escaped quotes (def: do not)\n"
     "\n"
     "\t[string ...]\tdecode strings on command line (def: read stdin)\n"

--- a/jstrencode.c
+++ b/jstrencode.c
@@ -58,7 +58,7 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit\n"
     "\t-t\t\tperform jencchk test on code JSON encode/decode functions\n"
     "\t-n\t\tdo not output newline after encode output (def: print final newline)\n"
-    "\t-Q\t\tignore enclosing \"'s (def: encode all bytes)\n"
+    "\t-Q\t\tdo not encode enclosing double quotes (def: encode all bytes)\n"
     "\n"
     "\t[string ...]\tencode strings on command line (def: read stdin)\n"
     "\t\t\tNOTE: - means read from stdin\n"

--- a/man/man1/jstrdecode.1
+++ b/man/man1/jstrdecode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrdecode 1 "12 September 2024" "jstrdecode" "jparse tools"
+.TH jstrdecode 1 "13 September 2024" "jstrdecode" "jparse tools"
 .SH NAME
 .B jstrdecode
 \- decode JSON encoded strings
@@ -68,7 +68,7 @@ Run tests on the JSON decode/encode functions.
 Do not output a newline after the decode function.
 .TP
 .B \-Q
-Enclose output in quotes.
+Enclose output in double quotes.
 .TP
 .B \-e
 Surround each decoded arg with escaped quotes.

--- a/man/man1/jstrencode.1
+++ b/man/man1/jstrencode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrencode 1 "12 September 2024" "jstrencode" "jparse tools"
+.TH jstrencode 1 "13 September 2024" "jstrencode" "jparse tools"
 .SH NAME
 .B jstrencode
 \- encode JSON encoded strings
@@ -57,7 +57,7 @@ Run tests on the JSON encode/encode functions.
 Do not output a newline after the encode function.
 .TP
 .B \-Q
-Enclose output in quotes (def: do not).
+Do not encode enclosing double quotes (def: encode all bytes),
 .SH EXIT STATUS
 .TP
 0


### PR DESCRIPTION
We mention that `-Q` refers to double quotes
in both the man pages and usage messages
for `jstrencode(1)` and `jstrdecode(1)`.