### PR TITLE
improve jstrdecode and jstrencode

### DIFF
--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -62,18 +62,9 @@
 #include "jparse.h"
 
 
-
 /*
  * globals
  */
-
-
-/*
- * function prototypes
- */
-static struct jstring *jstrdecode_stream(FILE *in_stream);
-static struct jstring *add_decoded_string(char *string, size_t bufsiz);
-static void free_json_decoded_strings(void);
 
 
 #endif /* INCLUDE_JSTRDECODE_H */

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -66,12 +66,4 @@
  */
 
 
-/*
- * forward declarations
- */
-static struct jstring *jstrencode_stream(FILE *in_stream, bool skip_quote);
-static struct jstring *add_encoded_string(char *string, size_t bufsiz);
-static void free_json_encoded_strings(void);
-
-
 #endif /* INCLUDE_JSTRENCODE_H */

--- a/man/man1/jstrdecode.1
+++ b/man/man1/jstrdecode.1
@@ -23,7 +23,6 @@
 .RB [\| \-t \|]
 .RB [\| \-n \|]
 .RB [\| \-Q \|]
-.RB [\| \-m \|]
 .RB [\| \-e \|]
 .RI [\| string
 .IR ... \|]
@@ -46,41 +45,35 @@ option it will surround each decoded arg with escaped (backslash) quotes.
 The use of
 .B \-Q
 and
-.B \-m
-(or its alias
-.BR \-e )
+.B \-e
 together will surround the entire output with unescaped quotes and each decoded arg's output will be surrounded with escaped (backslashed) quotes.
 .SH OPTIONS
 .TP
 .B \-h
-Show help and exit.
+Show help and exit
 .TP
 .BI \-v\  level
 Set verbosity level to
 .IR level
-(def: 0).
+(def: 0)
 .TP
 .B \-q
-Suppresses some of the output (def: not quiet).
+Suppresses some of the output (def: not quiet)
 .TP
 .B \-V
-Show version and exit.
+Show version and exit
 .TP
 .B \-t
-Run tests on the JSON decode/encode functions.
+Run tests on the JSON decode/encode functions
 .TP
 .B \-n
-Do not output a newline after the decode function.
+Do not output a newline after the decode function
 .TP
 .B \-Q
-Enclose output in double quotes.
-.TP
-.B \-m
-Surround each decoded arg with escaped quotes.
+Enclose output in double quotes
 .TP
 .B \-e
-Alias for
-.BR \-m .
+Surround each decoded arg with escaped double quotes
 .SH EXIT STATUS
 .TP
 0

--- a/man/man1/jstrencode.1
+++ b/man/man1/jstrencode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrencode 1 "13 September 2024" "jstrencode" "jparse tools"
+.TH jstrencode 1 "14 September 2024" "jstrencode" "jparse tools"
 .SH NAME
 .B jstrencode
 \- encode JSON encoded strings
@@ -27,7 +27,7 @@
 .IR ... \|]
 .SH DESCRIPTION
 .B jstrencode
-encodes JSON encoded strings given on the command line.
+Concatenate the string arguments and encode the result as if it were a JSON string.
 If given the
 .B \-t
 option it performs a test on the JSON encode and encode functions.
@@ -42,22 +42,25 @@ Show help and exit.
 .BI \-v\  level
 Set verbosity level to
 .I level
-(def: 0).
+(def: 0)
 .TP
 .B \-q
-Suppresses some of the output (def: not quiet).
+Suppresses some of the output (def: not quiet)
 .TP
 .B \-V
 Show version and exit.
 .TP
 .B \-t
-Run tests on the JSON encode/encode functions.
+Run tests on the JSON encode/encode functions
 .TP
 .B \-n
-Do not output a newline after the encode function.
+Do not output a newline after the encode function
 .TP
 .B \-Q
-Do not encode enclosing double quotes (def: encode all bytes),
+Do not encode double quotes that enclose the concatenation of args (def: do encode)
+.TP
+.B \-e
+Do not encode double quotes that enclose each arg (def: do encode)
 .SH EXIT STATUS
 .TP
 0


### PR DESCRIPTION
Added `-e` to `jstrencode`.

Improved the `jstrencode(1)` man page text and usage message.

Removed `-m` from `jstrdecode`,

Improved the `jstrdecode(1)` man page text and usage message.

Performed `make release` to test the above.