### PR TITLE
rename jenc to byte2asciistr, avoid confusion about purpose

### DIFF
--- a/json_parse.h
+++ b/json_parse.h
@@ -42,11 +42,15 @@
 
 
 /*
- * JSON encoding of an octet in a JSON string
+ * byte2asciistr - a trivial way to map an 8-bit byte into string of ASCII characters
  *
  * NOTE: this table assumes we process on a byte basis.
+ *
+ * XXX - This is NOT the canonical way to encode Unicode characters! - XXX
+ * XXX - Valid Unicode symbols when encoded as UTF-8 bytes should be - XXX
+ * XXX - encoded as 1 or more consecutive \\u[0-9A-Fa-f]{4} strings! - XXX
  */
-struct encode
+struct byte2asciistr
 {
     const u_int8_t byte;    /* 8 bit character to encode */
     const size_t len;	    /* length of encoding */
@@ -462,10 +466,18 @@ struct json
 
 /*
  * external data structures
- *
- * NOTE: this table assumes we process on an 8-bit byte basis.
  */
-extern struct encode jenc[];
+
+/*
+ * byte2asciistr - a trivial way to map an 8-bit byte into string of ASCII characters
+ *
+ * NOTE: This table assumes we process on an 8-bit byte basis.
+ *
+ * XXX - This is NOT the canonical way to encode Unicode characters! - XXX
+ * XXX - Valid Unicode symbols when encoded as UTF-8 bytes should be - XXX
+ * XXX - encoded as 1 or more consecutive \\u[0-9A-Fa-f]{4} strings! - XXX
+ */
+extern struct byte2asciistr byte2asciistr[];
 
 
 /*

--- a/json_util.c
+++ b/json_util.c
@@ -362,9 +362,13 @@ json_putc(uint8_t const c, FILE *stream)
 
     /*
      * write JSON encoding to stream
+     *
+     * XXX - This is NOT the canonical way to encode Unicode characters! - XXX
+     * XXX - Valid Unicode symbols when encoded as UTF-8 bytes should be - XXX
+     * XXX - encoded as 1 or more consecutive \\u[0-9A-Fa-f]{4} strings! - XXX
      */
     errno = 0;	    /* pre-clear errno for warnp */
-    ret = fprintf(stream, "%s", jenc[c].enc);
+    ret = fprintf(stream, "%s", byte2asciistr[c].enc);
     if (chk_stdio_printf_err(stream, ret)) {
 	warnp(__func__, "fprintf #1 error");
 	return false;

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -56,7 +56,7 @@ static const char * const usage_msg =
     "\t-v level\tset verbosity level (def level: %d)\n"
     "\t-q\t\tquiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit\n"
-    "\t-t\t\tperform jencchk test on code JSON decode/encode functions\n"
+    "\t-t\t\tperform tests of JSON decode/encode functionality\n"
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-Q\t\tenclose output in double quotes (def: do not)\n"
     "\t-e\t\tenclose each decoded string with escaped double quotes (def: do not)\n"
@@ -302,10 +302,13 @@ main(int argc, char **argv)
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
-	case 't':		/* -t - validate the contents of the jenc[] table */
-	    print("%s: Beginning jencchk test on code JSON decode/decode functions ...\n", program);
+	case 't':		/* -t - validate the contents of the byte2asciistr[] table */
+	    print("%s: Beginning jencchk test of the byte2asciistr table...\n", program);
 	    jencchk();
-	    print("%s: ... passed JSON decode/decode test\n", program);
+	    print("%s: ... passed byte2asciistr table test\n", program);
+	    print("%s: Beginning tests of JSON decode/encode functionality ...\n", program);
+	    print("%s: XXX - JSON encode/decode tests not yet written - XXX\n", program);
+	    print("%s: ... passed JSON encode/decode tests\n", program);
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;

--- a/jstrencode.c
+++ b/jstrencode.c
@@ -56,7 +56,7 @@ static const char * const usage_msg =
     "\t-v level\tset verbosity level: (def level: %d)\n"
     "\t-q\t\tquiet mode: silence msg(), warn(), warnp() if -v 0 (def: not quiet)\n"
     "\t-V\t\tprint version string and exit\n"
-    "\t-t\t\tperform jencchk test on code JSON encode/decode functions\n"
+    "\t-t\t\tperform tests of JSON decode/encode functionality\n"
     "\t-n\t\tdo not output newline after encode output (def: print final newline)\n"
     "\t-Q\t\tdo not encode double quotes that enclose the concatenation of args (def: do encode)\n"
     "\t-e\t\tdo not output double quotes that enclose each arg (def: do not remove)\n"
@@ -366,10 +366,13 @@ main(int argc, char **argv)
 	    exit(2); /*ooo*/
 	    not_reached();
 	    break;
-	case 't':		/* -t - validate the contents of the jenc[] table */
-	    print("%s: Beginning jencchk test on code JSON encode/decode functions ...\n", program);
+	case 't':		/* -t - validate the contents of the byte2asciistr[] table */
+	    print("%s: Beginning jencchk test of the byte2asciistr table...\n", program);
 	    jencchk();
-	    print("%s: ... passed JSON encode/decode test\n", program);
+	    print("%s: ... passed byte2asciistr table test\n", program);
+	    print("%s: Beginning tests of JSON decode/encode functionality ...\n", program);
+	    print("%s: XXX - JSON encode/decode tests not yet written - XXX\n", program);
+	    print("%s: ... passed JSON encode/decode tests\n", program);
 	    exit(0); /*ooo*/
 	    not_reached();
 	    break;


### PR DESCRIPTION
We need to be more exact about the `jenc[]` does the purpose of `struct encode`, and what `jstrencode -t` and `jstrdecode -t` do, so we rename:

- jenc to byte2asciistr
- struct encode to struct byte2asciistr

This is to avoid any potential confusion about the table performing any sort of true JSON encoding / decoding.

The table provides a trivial way to map an 8-bit byte into string of ASCII characters.  We say "trivial" because the table converts 8-bit bytes in string of ASCII characters that is technically valid for encoded JSON strings even though they may not be canonical.

A valid Unicode symbol canonically should be encoded as 1 or more consecutive "\uHexHexHexHex" string combinations.

The "trivial" way to map 8-bit bytes into a string of ASCII characters that happens to not violate the so-called JSON specification. For example, the Unicode `à` character (U+00E0) is "hacked" into the ASCII string "\xe0", a 0xe0 byte followed by a NUL byte.  In truth, the `à` character is passed along as an 8-bit binary value.  The canonical encoding would be (probably) "\\u00e0", a string of 6 ASCII characters.

The action of `jstrencode -t` and `jstrdecode -t` at present, only preformed a sanity test of the "trivial" way to map 8-bit bytes into a string of ASCII characters.  And while the table remains in use, the table sanity test is mildly useful but should **NOT** be considered a test of of JSON encoding / decoding.

The `jstrencode -t` output, for example, now prints:

```
./jstrencode: Beginning jencchk test of the byte2asciistr table...
./jstrencode: ... passed byte2asciistr table test
./jstrencode: Beginning tests of JSON decode/encode functionality ...
./jstrencode: XXX - JSON encode/decode tests not yet written - XXX
./jstrencode: ... passed JSON encode/decode tests
```

When [issue #13](https://github.com/xexyl/jparse/issues/13) is finally fixed, there may be useful tests that the `-t` might perform.  If so, then the code it invokes should be updated accordingly.