### PR TITLE
improve jstrdecode -N

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,8 +25,8 @@ Add new option `-N` to `jstrdecode(1)`. This option ignores a final newline in
 the input for easier typing of commands. It does not change the validity
 checking of JSON.
 
-Add new option `-N` to `jstrencode(1)`. This option ignores a final newline in
-the input. It does not change the validity checking of JSON.
+Add new option `-N` to `jstrencode(1)`. This option ignores all newlines in
+decoding data. It does not change the validity checking of JSON.
 
 
 ## Release 1.2.0 2024-10-09

--- a/json_parse.c
+++ b/json_parse.c
@@ -446,7 +446,7 @@ jdecencchk(void)
     /* test json_decode_str() */
     mstr2 = json_decode_str(decstr, &mlen2);
     if (mstr2 == NULL) {
-	err(147, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
+	err(150, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
 			   decstr, (uintmax_t)mlen2);
 	not_reached();
     }
@@ -460,7 +460,7 @@ jdecencchk(void)
     dbg(DBG_VVVHIGH, "testing json_encode(mstr2, 1, mlen): %s", mstr2);
     mstr = json_encode(mstr2, mlen2, &mlen, false);
     if (mstr == NULL) {
-	err(148, __func__, "json_encode(mstr2: %s, mlen2: %ju, mlen: %ju) == NULL", mstr2, (uintmax_t)mlen2, (uintmax_t)mlen);
+	err(151, __func__, "json_encode(mstr2: %s, mlen2: %ju, mlen: %ju) == NULL", mstr2, (uintmax_t)mlen2, (uintmax_t)mlen);
 	not_reached();
     }
     dbg(DBG_HIGH, "encoded string: %s (len: %ju)", mstr, mlen);
@@ -470,7 +470,7 @@ jdecencchk(void)
      * verify that the encoded string matches the original string
      */
     if (strcmp(mstr2, mstr) != 0) {
-	err(149, __func__, "mstr2: %s != decstr: %s", mstr2, mstr);
+	err(152, __func__, "mstr2: %s != decstr: %s", mstr2, mstr);
 	not_reached();
     } else {
 	dbg(DBG_MED, "%s: %s == %s: true", decstr, mstr, mstr2);
@@ -522,7 +522,7 @@ chkbyte2asciistr(void)
      * assert: bits in byte must be 8
      */
     if (BITS_IN_BYTE != 8) {
-	err(150, __func__, "BITS_IN_BYTE: %d != 8", BITS_IN_BYTE);
+	err(153, __func__, "BITS_IN_BYTE: %d != 8", BITS_IN_BYTE);
 	not_reached();
     }
 
@@ -530,7 +530,7 @@ chkbyte2asciistr(void)
      * assert: JSON_BYTE_VALUES must be 256
      */
     if (JSON_BYTE_VALUES != 256) {
-	err(151, __func__, "JSON_BYTE_VALUES: %d != 256", JSON_BYTE_VALUES);
+	err(154, __func__, "JSON_BYTE_VALUES: %d != 256", JSON_BYTE_VALUES);
 	not_reached();
     }
 
@@ -538,7 +538,7 @@ chkbyte2asciistr(void)
      * assert: table must be of size 256
      */
     if (TBLLEN(byte2asciistr) != JSON_BYTE_VALUES) {
-	err(152, __func__, "byte2asciistr table length is %ju instead of %d",
+	err(155, __func__, "byte2asciistr table length is %ju instead of %d",
 			   (uintmax_t)TBLLEN(byte2asciistr), JSON_BYTE_VALUES);
 	not_reached();
     }
@@ -548,7 +548,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (byte2asciistr[i].byte != i) {
-	    err(153, __func__, "byte2asciistr[0x%02x].byte: %d != %d", i, byte2asciistr[i].byte, i);
+	    err(156, __func__, "byte2asciistr[0x%02x].byte: %d != %d", i, byte2asciistr[i].byte, i);
 	    not_reached();
 	}
     }
@@ -558,7 +558,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (byte2asciistr[i].enc == NULL) {
-	    err(154, __func__, "byte2asciistr[0x%02x].enc == NULL", i);
+	    err(157, __func__, "byte2asciistr[0x%02x].enc == NULL", i);
 	    not_reached();
 	}
     }
@@ -568,7 +568,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (strlen(byte2asciistr[i].enc) != byte2asciistr[i].len) {
-	    err(155, __func__, "byte2asciistr[0x%02x].enc length: %ju != byte2asciistr[0x%02x].len: %ju",
+	    err(158, __func__, "byte2asciistr[0x%02x].enc length: %ju != byte2asciistr[0x%02x].len: %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       i, (uintmax_t)byte2asciistr[i].len);
 	    not_reached();
@@ -580,18 +580,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x00; i <= 0x07; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(156, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	    err(159, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(157, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(160, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(158, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(161, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -602,13 +602,13 @@ chkbyte2asciistr(void)
     indx = 0x08;
     encstr = "\\b";
     if (byte2asciistr[indx].len != LITLEN("\\b")) {
-	err(159, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(162, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(160, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(163, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -618,13 +618,13 @@ chkbyte2asciistr(void)
     indx = 0x09;
     encstr = "\\t";
     if (byte2asciistr[indx].len != LITLEN("\\b")) {
-	err(161, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(164, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(162, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(165, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -634,13 +634,13 @@ chkbyte2asciistr(void)
     indx = 0x0a;
     encstr = "\\n";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(163, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(166, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(164, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(167, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -650,13 +650,13 @@ chkbyte2asciistr(void)
     indx = 0x0b;
     encstr = "\\u000b";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(165, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(168, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(166, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(169, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -666,13 +666,13 @@ chkbyte2asciistr(void)
     indx = 0x0c;
     encstr = "\\f";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(167, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(170, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(168, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(171, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -682,13 +682,13 @@ chkbyte2asciistr(void)
     indx = 0x0d;
     encstr = "\\r";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(169, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(172, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(170, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(173, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -697,18 +697,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x0e; i <= 0x1f; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(171, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	    err(174, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(172, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(175, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(173, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(176, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -718,12 +718,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x20; i <= 0x21; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(174, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(177, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(175, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(178, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -734,13 +734,13 @@ chkbyte2asciistr(void)
     indx = 0x22;
     encstr = "\\\"";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(176, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(179, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(177, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(180, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -749,12 +749,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x23; i <= 0x5b; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(178, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(181, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(179, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(182, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -765,13 +765,13 @@ chkbyte2asciistr(void)
     indx = 0x5c;
     encstr = "\\\\";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(180, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	err(183, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			   indx, (uintmax_t)strlen(byte2asciistr[indx].enc),
 			   (uintmax_t)strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(181, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(184, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -780,12 +780,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x5d; i <= 0x7e; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(182, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(185, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(183, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(186, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -795,18 +795,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x7f; i <= 0x7f; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(184, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
+	    err(187, __func__, "byte2asciistr[0x%02x].enc length: %ju != %ju",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc),
 			       (uintmax_t)LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(185, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(188, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(186, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(189, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -816,17 +816,17 @@ chkbyte2asciistr(void)
      */
     for (i=0x80; i <= 0xff; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(187, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
+	    err(190, __func__, "byte2asciistr[0x%02x].enc length: %ju != %d",
 			       i, (uintmax_t)strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((uint8_t)(byte2asciistr[i].enc[0]) != i) {
-	    err(188, __func__, "byte2asciistr[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
+	    err(191, __func__, "byte2asciistr[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
 			       i, (uint8_t)(byte2asciistr[i].enc[0]) & 0xff, (uintmax_t)i);
 	    not_reached();
 	}
 	if ((uint8_t)(byte2asciistr[i].enc[1]) != 0) {
-	    err(189, __func__, "byte2asciistr[0x%02x].enc[1]: 0x%02x is not 0",
+	    err(192, __func__, "byte2asciistr[0x%02x].enc[1]: 0x%02x is not 0",
 			       i, (uint8_t)(byte2asciistr[i].enc[1]) & 0xff);
 	    not_reached();
 	}
@@ -839,16 +839,16 @@ chkbyte2asciistr(void)
     memset(str, 0, sizeof(str));    /* clear all bytes in str, including the final '\0' */
     mstr = json_encode(str, 1,  &mlen, false);
     if (mstr == NULL) {
-	err(190, __func__, "json_encode(0x00, 1, *mlen: %ju) == NULL", (uintmax_t)mlen);
+	err(193, __func__, "json_encode(0x00, 1, *mlen: %ju) == NULL", (uintmax_t)mlen);
 	not_reached();
     }
     if (mlen != byte2asciistr[0].len) {
-	err(191, __func__, "json_encode(0x00, 1, *mlen: %ju != %ju)",
+	err(194, __func__, "json_encode(0x00, 1, *mlen: %ju != %ju)",
 			   (uintmax_t)mlen, (uintmax_t)(byte2asciistr[0].len));
 	not_reached();
     }
     if (strcmp(byte2asciistr[0].enc, mstr) != 0) {
-	err(192, __func__, "json_encode(0x00, 1, *mlen: %ju) != <%s>",
+	err(195, __func__, "json_encode(0x00, 1, *mlen: %ju) != <%s>",
 			   (uintmax_t)mlen, byte2asciistr[0].enc);
 	not_reached();
     }
@@ -873,17 +873,17 @@ chkbyte2asciistr(void)
 	mstr = json_encode_str(str, &mlen, false);
 	/* check encoding result */
 	if (mstr == NULL) {
-	    err(193, __func__, "json_encode_str(0x%02x, *mlen: %ju) == NULL",
+	    err(196, __func__, "json_encode_str(0x%02x, *mlen: %ju) == NULL",
 			       i, (uintmax_t)mlen);
 	    not_reached();
 	}
 	if (mlen != byte2asciistr[i].len) {
-	    err(194, __func__, "json_encode_str(0x%02x, *mlen %ju != %ju)",
+	    err(197, __func__, "json_encode_str(0x%02x, *mlen %ju != %ju)",
 			       i, (uintmax_t)mlen, (uintmax_t)byte2asciistr[i].len);
 	    not_reached();
 	}
 	if (strcmp(byte2asciistr[i].enc, mstr) != 0) {
-	    err(195, __func__, "json_encode_str(0x%02x, *mlen: %ju) != <%s>", i,
+	    err(198, __func__, "json_encode_str(0x%02x, *mlen: %ju) != <%s>", i,
 			       (uintmax_t)mlen, byte2asciistr[i].enc);
 	    not_reached();
 	}
@@ -896,17 +896,17 @@ chkbyte2asciistr(void)
 	/* test json_decode_str() */
 	mstr2 = json_decode_str(mstr, &mlen2);
 	if (mstr2 == NULL) {
-	    err(196, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
+	    err(199, __func__, "json_decode_str(<%s>, *mlen2: %ju) == NULL",
 			       mstr, (uintmax_t)mlen2);
 	    not_reached();
 	}
 	if (mlen2 != byte2asciistr[i].decoded_len) {
-	    err(197, __func__, "json_decode_str(<%s>, *mlen2 %ju != %ju)",
+	    err(200, __func__, "json_decode_str(<%s>, *mlen2 %ju != %ju)",
 			       mstr, (uintmax_t)mlen2, byte2asciistr[i].decoded_len);
 	    not_reached();
 	}
 	if ((uint8_t)(mstr2[0]) != i) {
-	    err(198, __func__, "json_decode_str(<%s>, *mlen2: %ju): 0x%02x != 0x%02x",
+	    err(201, __func__, "json_decode_str(<%s>, *mlen2: %ju): 0x%02x != 0x%02x",
 			       mstr, (uintmax_t)mlen2, (uint8_t)(mstr2[0]) & 0xff, i);
 	    not_reached();
 	}
@@ -1586,7 +1586,7 @@ parse_json_string(char const *string, size_t len)
      * firewall
      */
     if (string == NULL) {
-	err(199, __func__, "passed NULL string");
+	err(202, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1601,15 +1601,15 @@ parse_json_string(char const *string, size_t len)
     str = json_conv_string(string, len, true);
     /* paranoia - these tests should never result in an error */
     if (str == NULL) {
-        err(200, __func__, "converting JSON string returned NULL: <%s>", string);
+        err(203, __func__, "converting JSON string returned NULL: <%s>", string);
         not_reached();
     } else if (str->type != JTYPE_STRING) {
-        err(201, __func__, "expected JTYPE_STRING, found type: %s", json_item_type_name(str));
+        err(204, __func__, "expected JTYPE_STRING, found type: %s", json_item_type_name(str));
         not_reached();
     }
     item = &(str->item.string);
     if (!VALID_JSON_NODE(item)) {
-	err(202, __func__, "couldn't parse string: <%s>", string);
+	err(205, __func__, "couldn't parse string: <%s>", string);
 	not_reached();
     }
     return str;
@@ -1638,17 +1638,17 @@ parse_json_bool(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(203, __func__, "passed NULL string");
+	err(206, __func__, "passed NULL string");
 	not_reached();
     }
 
     boolean = json_conv_bool_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (boolean == NULL) {
-	err(204, __func__, "converting JSON bool returned NULL: <%s>", string);
+	err(207, __func__, "converting JSON bool returned NULL: <%s>", string);
 	not_reached();
     } else if (boolean->type != JTYPE_BOOL) {
-        err(205, __func__, "expected JTYPE_BOOL, found type: %s", json_item_type_name(boolean));
+        err(208, __func__, "expected JTYPE_BOOL, found type: %s", json_item_type_name(boolean));
         not_reached();
     }
     item = &(boolean->item.boolean);
@@ -1663,18 +1663,18 @@ parse_json_bool(char const *string)
 	 * If it's not we abort as there's a serious mismatch between the
 	 * scanner and the parser.
 	 */
-	err(206, __func__, "called on non-boolean string: <%s>", string);
+	err(209, __func__, "called on non-boolean string: <%s>", string);
 	not_reached();
     } else if (item->as_str == NULL) {
 	/* extra sanity check - make sure the allocated string != NULL */
-	err(207, __func__, "boolean->as_str == NULL");
+	err(210, __func__, "boolean->as_str == NULL");
 	not_reached();
     } else if (strcmp(item->as_str, "true") && strcmp(item->as_str, "false")) {
 	/*
 	 * extra sanity check - make sure the allocated string is "true"
 	 * or "false"
 	 */
-	err(208, __func__, "boolean->as_str neither \"true\" nor \"false\"");
+	err(211, __func__, "boolean->as_str neither \"true\" nor \"false\"");
 	not_reached();
     } else {
 	/*
@@ -1683,16 +1683,16 @@ parse_json_bool(char const *string)
 	 */
 	char const *str = booltostr(item->value);
 	if (str == NULL) {
-	    err(209, __func__, "could not convert boolean->value back to a string");
+	    err(212, __func__, "could not convert boolean->value back to a string");
 	    not_reached();
 	} else if (strcmp(str, item->as_str)) {
-	    err(210, __func__, "boolean->as_str != item->value as a string");
+	    err(213, __func__, "boolean->as_str != item->value as a string");
 	    not_reached();
 	} else if (strtobool(item->as_str) != item->value) {
-	    err(211, __func__, "mismatch between boolean string and converted value");
+	    err(214, __func__, "mismatch between boolean string and converted value");
 	    not_reached();
 	} else if (strtobool(str) != item->value) {
-	    err(212, __func__, "mismatch between converted string value and converted value");
+	    err(215, __func__, "mismatch between converted string value and converted value");
 	    not_reached();
 	}
     }
@@ -1723,7 +1723,7 @@ parse_json_null(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(213, __func__, "passed NULL string");
+	err(216, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1733,16 +1733,16 @@ parse_json_null(char const *string)
     null = json_conv_null_str(string, NULL);
     if (null == NULL) {
 	/* ironically null is NULL and it actually should not be :-) */
-	err(214, __func__, "null is NULL");
+	err(217, __func__, "null is NULL");
 	not_reached();
     } else if (null->type != JTYPE_NULL) {
-        err(215, __func__, "expected JTYPE_NULL, found type: %s", json_item_type_name(null));
+        err(218, __func__, "expected JTYPE_NULL, found type: %s", json_item_type_name(null));
         not_reached();
     }
     item = &(null->item.null);
     if (!VALID_JSON_NODE(item)) {
 	/* why is it an error if we can't convert nothing ? :-) */
-	err(216,__func__, "couldn't convert null: <%s>", string);
+	err(219,__func__, "couldn't convert null: <%s>", string);
 	not_reached();
     }
 
@@ -1772,7 +1772,7 @@ parse_json_number(char const *string)
      * firewall
      */
     if (string == NULL) {
-	err(217, __func__, "passed NULL string");
+	err(220, __func__, "passed NULL string");
 	not_reached();
     }
 
@@ -1782,15 +1782,15 @@ parse_json_number(char const *string)
     number = json_conv_number_str(string, NULL);
     /* paranoia - these tests should never result in an error */
     if (number == NULL) {
-	err(218, __func__, "converting JSON number returned NULL: <%s>", string);
+	err(221, __func__, "converting JSON number returned NULL: <%s>", string);
         not_reached();
     } else if (number->type != JTYPE_NUMBER) {
-        err(219, __func__, "expected JTYPE_NUMBER, found type: %s", json_item_type_name(number));
+        err(222, __func__, "expected JTYPE_NUMBER, found type: %s", json_item_type_name(number));
         not_reached();
     }
     item = &(number->item.number);
     if (!VALID_JSON_NODE(item)) {
-	err(220, __func__, "couldn't convert number string: <%s>", string);
+	err(223, __func__, "couldn't convert number string: <%s>", string);
 	not_reached();
     }
     return number;
@@ -1823,11 +1823,11 @@ parse_json_array(struct json *elements)
      * firewall
      */
     if (elements == NULL) {
-	err(221, __func__, "passed NULL elements value");
+	err(224, __func__, "passed NULL elements value");
 	not_reached();
     }
     if (elements->type != JTYPE_ELEMENTS) {
-	err(222, __func__, "expected type JTYPE_ELEMENTS: found: %s (%d)",
+	err(225, __func__, "expected type JTYPE_ELEMENTS: found: %s (%d)",
 			   json_item_type_name(elements), elements->type);
 	not_reached();
     }
@@ -1841,7 +1841,7 @@ parse_json_array(struct json *elements)
     /* paranoia - these tests should never result in an error */
     item = &(elements->item.array);
     if (!VALID_JSON_NODE(item)) {
-	err(223, __func__, "couldn't convert array");
+	err(226, __func__, "couldn't convert array");
 	not_reached();
     }
     return elements;
@@ -1871,14 +1871,14 @@ parse_json_member(struct json *name, struct json *value)
      * firewall
      */
     if (name == NULL) {
-	err(224, __func__, "passed NULL name value");
+	err(227, __func__, "passed NULL name value");
 	not_reached();
     } else if (value == NULL) {
-	err(225, __func__, "passed NULL value");
+	err(228, __func__, "passed NULL value");
 	not_reached();
     }
     if (name->type != JTYPE_STRING) {
-	err(226, __func__, "expected name->type == JTYPE_STRING: is %s (%d)", json_item_type_name(name), name->type);
+	err(229, __func__, "expected name->type == JTYPE_STRING: is %s (%d)", json_item_type_name(name), name->type);
 	not_reached();
     }
 
@@ -1888,15 +1888,15 @@ parse_json_member(struct json *name, struct json *value)
     member = json_conv_member(name, value);
     /* paranoia - these tests should never result in an error */
     if (member == NULL) {
-	err(227, __func__, "converting JSON member returned NULL");
+	err(230, __func__, "converting JSON member returned NULL");
 	not_reached();
     } else if (member->type != JTYPE_MEMBER) {
-        err(228, __func__, "expected JTYPE_MEMBER, found type: %s", json_item_type_name(member));
+        err(231, __func__, "expected JTYPE_MEMBER, found type: %s", json_item_type_name(member));
         not_reached();
     }
     item = &(member->item.member);
     if (!VALID_JSON_NODE(item)) {
-	err(229, __func__, "couldn't convert member");
+	err(232, __func__, "couldn't convert member");
 	not_reached();
     }
     return member;
@@ -1945,7 +1945,7 @@ json_alloc(enum item_type type)
     errno = 0;			/* pre-clear errno for errp() */
     ret = calloc(1, sizeof(*ret));
     if (ret == NULL) {
-	errp(230, __func__, "calloc #0 error allocating %ju bytes", (uintmax_t)sizeof(*ret));
+	errp(233, __func__, "calloc #0 error allocating %ju bytes", (uintmax_t)sizeof(*ret));
 	not_reached();
     }
 
@@ -2773,7 +2773,7 @@ json_conv_number(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_NUMBER);
     if (ret == NULL) {
-	errp(231, __func__, "json_alloc(JTYPE_NUMBER) returned NULL");
+	errp(234, __func__, "json_alloc(JTYPE_NUMBER) returned NULL");
 	not_reached();
     }
 
@@ -2843,7 +2843,7 @@ json_conv_number(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));
     if (item->as_str == NULL) {
-	errp(232, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(235, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     strncpy(item->as_str, ptr, len);
@@ -3010,7 +3010,7 @@ json_conv_number_str(char const *str, size_t *retlen)
      */
     ret = json_conv_number(str, len);
     if (ret == NULL) {
-	err(233, __func__, "json_conv_number() returned NULL");
+	err(236, __func__, "json_conv_number() returned NULL");
 	not_reached();
     }
 
@@ -3063,7 +3063,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
      */
     ret = json_alloc(JTYPE_STRING);
     if (ret == NULL) {
-	errp(234, __func__, "json_alloc(JTYPE_STRING) returned NULL");
+	errp(237, __func__, "json_alloc(JTYPE_STRING) returned NULL");
 	not_reached();
     }
 
@@ -3126,7 +3126,7 @@ json_conv_string(char const *ptr, size_t len, bool quote)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = calloc(len+1+1, sizeof(char));
     if (item->as_str == NULL) {
-	errp(235, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(238, __func__, "calloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     strncpy(item->as_str, ptr, len);
@@ -3211,7 +3211,7 @@ json_conv_string_str(char const *str, size_t *retlen, bool quote)
      */
     ret = json_conv_string(str, len, quote);
     if (ret == NULL) {
-	err(236, __func__, "json_conv_string() returned NULL");
+	err(239, __func__, "json_conv_string() returned NULL");
 	not_reached();
     }
 
@@ -3258,7 +3258,7 @@ json_conv_bool(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_BOOL);
     if (ret == NULL) {
-	errp(237, __func__, "json_alloc(JTYPE_BOOL) returned NULL");
+	errp(240, __func__, "json_alloc(JTYPE_BOOL) returned NULL");
 	not_reached();
     }
 
@@ -3293,7 +3293,7 @@ json_conv_bool(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = malloc(len+1+1);
     if (item->as_str == NULL) {
-	errp(238, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(241, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     memcpy(item->as_str, ptr, len+1);
@@ -3367,7 +3367,7 @@ json_conv_bool_str(char const *str, size_t *retlen)
      */
     ret = json_conv_bool(str, len);
     if (ret == NULL) {
-	err(239, __func__, "json_conv_bool(%s, %jd) returned NULL", str, (uintmax_t)len);
+	err(242, __func__, "json_conv_bool(%s, %jd) returned NULL", str, (uintmax_t)len);
 	not_reached();
     }
 
@@ -3413,7 +3413,7 @@ json_conv_null(char const *ptr, size_t len)
      */
     ret = json_alloc(JTYPE_NULL);
     if (ret == NULL) {
-	errp(240, __func__, "json_alloc(JTYPE_NULL) returned NULL");
+	errp(243, __func__, "json_alloc(JTYPE_NULL) returned NULL");
 	not_reached();
     }
 
@@ -3448,7 +3448,7 @@ json_conv_null(char const *ptr, size_t len)
     errno = 0;			/* pre-clear errno for errp() */
     item->as_str = malloc(len+1+1);
     if (item->as_str == NULL) {
-	errp(241, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
+	errp(244, __func__, "malloc #1 error allocating %ju bytes", (uintmax_t)(len+1+1));
 	not_reached();
     }
     memcpy(item->as_str, ptr, len+1);
@@ -3518,7 +3518,7 @@ json_conv_null_str(char const *str, size_t *retlen)
      */
     ret = json_conv_null(str, len);
     if (ret == NULL) {
-	err(242, __func__, "json_conv_null() returned NULL");
+	err(245, __func__, "json_conv_null() returned NULL");
 	not_reached();
     }
 
@@ -3578,7 +3578,7 @@ json_conv_member(struct json *name, struct json *value)
      */
     ret = json_alloc(JTYPE_MEMBER);
     if (ret == NULL) {
-	errp(243, __func__, "json_alloc(JTYPE_MEMBER) returned NULL");
+	errp(246, __func__, "json_alloc(JTYPE_MEMBER) returned NULL");
 	not_reached();
     }
 
@@ -3651,13 +3651,13 @@ json_conv_member(struct json *name, struct json *value)
     item->name_as_str = item2->as_str;
     /* paranoia */
     if (item->name_as_str == NULL) {
-	err(244, __func__, "item->name_as_str is NULL");
+	err(247, __func__, "item->name_as_str is NULL");
 	not_reached();
     }
     item->name_str = item2->str;
     /* paranoia */
     if (item->name_str == NULL) {
-	err(245, __func__, "item->name_str is NULL");
+	err(248, __func__, "item->name_str is NULL");
 	not_reached();
     }
     item->name_as_str_len = item2->as_str_len;
@@ -3699,7 +3699,7 @@ json_create_object(void)
      */
     ret = json_alloc(JTYPE_OBJECT);
     if (ret == NULL) {
-	errp(246, __func__, "json_alloc(JTYPE_OBJECT) returned NULL");
+	errp(249, __func__, "json_alloc(JTYPE_OBJECT) returned NULL");
 	not_reached();
     }
 
@@ -3718,7 +3718,7 @@ json_create_object(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(247, __func__, "dyn_array_create() returned NULL");
+	errp(10, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 
@@ -3772,20 +3772,20 @@ json_object_add_member(struct json *node, struct json *member)
      * firewall
      */
     if (node == NULL) {
-	err(248, __func__, "node is NULL");
+	err(11, __func__, "node is NULL");
 	not_reached();
     }
     if (member == NULL) {
-	err(249, __func__, "member is NULL");
+	err(12, __func__, "member is NULL");
 	not_reached();
     }
     if (node->type != JTYPE_OBJECT) {
-	err(10, __func__, "object node type expected to be JTYPE_OBJECT: %d found type: %d",
+	err(13, __func__, "object node type expected to be JTYPE_OBJECT: %d found type: %d",
 		           JTYPE_OBJECT, node->type);
 	not_reached();
     }
     if (member->type != JTYPE_MEMBER) {
-	err(11, __func__, "object member type expected to be JTYPE_MEMBER: %d found type: %d",
+	err(14, __func__, "object member type expected to be JTYPE_MEMBER: %d found type: %d",
 		           JTYPE_MEMBER, node->type);
 	not_reached();
     }
@@ -3795,7 +3795,7 @@ json_object_add_member(struct json *node, struct json *member)
      */
     item = &(node->item.object);
     if (item->s == NULL) {
-	err(12, __func__, "item->s is NULL");
+	err(15, __func__, "item->s is NULL");
 	not_reached();
     }
 
@@ -3852,7 +3852,7 @@ json_create_elements(void)
      */
     ret = json_alloc(JTYPE_ELEMENTS);
     if (ret == NULL) {
-	errp(13, __func__, "json_alloc(JTYPE_ELEMENTS) returned NULL");
+	errp(16, __func__, "json_alloc(JTYPE_ELEMENTS) returned NULL");
 	not_reached();
     }
 
@@ -3871,7 +3871,7 @@ json_create_elements(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(14, __func__, "dyn_array_create() returned NULL");
+	errp(17, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 
@@ -3923,15 +3923,15 @@ json_elements_add_value(struct json *node, struct json *value)
      * firewall
      */
     if (node == NULL) {
-	err(15, __func__, "node is NULL");
+	err(18, __func__, "node is NULL");
 	not_reached();
     }
     if (value == NULL) {
-	err(16, __func__, "value is NULL");
+	err(19, __func__, "value is NULL");
 	not_reached();
     }
     if (node->type != JTYPE_ELEMENTS) {
-	err(17, __func__, "node type expected to be JTYPE_ELEMENTS: %d found type: %d",
+	err(20, __func__, "node type expected to be JTYPE_ELEMENTS: %d found type: %d",
 			   JTYPE_ELEMENTS, node->type);
 	not_reached();
     }
@@ -3947,11 +3947,11 @@ json_elements_add_value(struct json *node, struct json *value)
 	json_dbg(JSON_DBG_VHIGH, __func__, "JSON item type: %s", json_item_type_name(value));
 	break;
     case JTYPE_ELEMENTS:
-	err(18, __func__, "JSON type %s (type: %d) is invalid here",
+	err(21, __func__, "JSON type %s (type: %d) is invalid here",
 		json_item_type_name(node), JTYPE_ELEMENTS);
 	not_reached();
     default:
-	err(19, __func__, "expected JSON item, array, string, number, boolean or null, found type: %d",
+	err(22, __func__, "expected JSON item, array, string, number, boolean or null, found type: %d",
 			   value->type);
 	not_reached();
     }
@@ -3961,7 +3961,7 @@ json_elements_add_value(struct json *node, struct json *value)
      */
     item = &(node->item.elements);
     if (item->s == NULL) {
-	err(20, __func__, "item->s is NULL");
+	err(23, __func__, "item->s is NULL");
 	not_reached();
     }
 
@@ -4017,7 +4017,7 @@ json_create_array(void)
      */
     ret = json_alloc(JTYPE_ARRAY);
     if (ret == NULL) {
-	errp(21, __func__, "json_alloc(JTYPE_ARRAY) returned NULL");
+	errp(24, __func__, "json_alloc(JTYPE_ARRAY) returned NULL");
 	not_reached();
     }
 
@@ -4036,7 +4036,7 @@ json_create_array(void)
      */
     item->s = dyn_array_create(sizeof (struct json *), JSON_CHUNK, JSON_CHUNK, true);
     if (item->s == NULL) {
-	errp(22, __func__, "dyn_array_create() returned NULL");
+	errp(25, __func__, "dyn_array_create() returned NULL");
 	not_reached();
     }
 

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -54,7 +54,7 @@ static const char * const usage_msg =
     "\t-V\t\tprint version string and exit\n"
     "\t-t\t\tperform tests of JSON decode/encode functionality\n"
     "\t-n\t\tdo not output newline after decode output\n"
-    "\t-N\t\tignore final newline in input\n"
+    "\t-N\t\tignore all newline characters\n"
     "\t-Q\t\tenclose output in double quotes (def: do not)\n"
     "\t-e\t\tenclose each decoded string with escaped double quotes (def: do not)\n"
     "\n"
@@ -77,7 +77,7 @@ static const char * const usage_msg =
  * forward declarations
  */
 static void usage(int exitcode, char const *prog, char const *str) __attribute__((noreturn));
-static struct jstring *jstrdecode_stream(FILE *in_stream, bool skip_eol_nl);
+static struct jstring *jstrdecode_stream(FILE *in_stream, bool ignore_nl);
 static struct jstring *add_decoded_string(char *string, size_t bufsiz);
 static void free_json_decoded_strings(void);
 
@@ -175,11 +175,73 @@ free_json_decoded_strings(void)
 
 
 /*
+ * dup_without_nl - duplicate a buffer and remove all newlines
+ *
+ * given:
+ *	input	    original input buffer
+ *	inputlen    pointer to the length of the input buffer
+ *
+ * returns:
+ *	malloced buffer without any newlines
+ *	NULL ==> malloc error, or NULL argument
+ *
+ * NOTE: If newlines were removed in the copy, then *inputlen will be updated
+ *	 to account for the new length.
+ */
+static char *
+dup_without_nl(char *input, size_t *inputlen)
+{
+    char *dup_input = NULL;	/* duplicate of input */
+    size_t i;
+    size_t j;
+
+    /*
+     * firewall
+     */
+    if (input == NULL) {
+	warn(__func__, "input is NULL");
+	return NULL;
+    }
+    if (inputlen == NULL) {
+	warn(__func__, "inputlen is NULL");
+	return NULL;
+    }
+
+    /*
+     * copy input removing all newlines
+     */
+    dup_input = malloc(*inputlen + 1);	/* + 1 for guard NUL byte */
+    if (dup_input == NULL) {
+	warn(__func__, "malloc of input failed");
+	return NULL;
+    }
+    for (i=0, j=0; i < *inputlen; ++i) {
+	if (input[i] != '\n') {
+	    dup_input[j++] = input[i];
+	}
+    }
+    dup_input[j] = '\0';    /* paranoia */
+
+    /*
+     * update inputlen if we removed newlines
+     */
+    if (j != i) {
+	*inputlen = j;
+    }
+
+    /*
+     * return success
+     */
+    return dup_input;
+}
+
+
+/*
  * jstrdecode_stream - decode an open file stream into a char *
  *
  * given:
  *	in_stream	open file stream to decode
- *	skip_eol_nl	true ==> ignore final newline
+ *	ignore_nl	true ==> ignore all newline characters
  *
  * returns:
  *	allocated struct jstring * ==> decoding was successful,
@@ -189,13 +251,14 @@ free_json_decoded_strings(void)
  * decoded JSON strings.
  */
 static struct jstring *
-jstrdecode_stream(FILE *in_stream, bool skip_eol_nl)
+jstrdecode_stream(FILE *in_stream, bool ignore_nl)
 {
     char *input = NULL;		/* argument to process */
     size_t inputlen;		/* length of input buffer */
     size_t bufsiz;		/* length of the buffer */
     char *buf = NULL;		/* decode buffer */
     struct jstring *jstr = NULL;    /* decoded string added to list */
+    char *dup_input = NULL;	/* duplicate of input w/o newlines */
 
     /*
      * firewall
@@ -217,13 +280,30 @@ jstrdecode_stream(FILE *in_stream, bool skip_eol_nl)
     dbg(DBG_MED, "stream read length: %ju", (uintmax_t)inputlen);
 
     /*
+     * if -N, remove all newlines from data
+     */
+    if (ignore_nl) {
+
+	/*
+	 * copy input removing all newlines, update inputlen if needed
+	 */
+	dup_input = dup_without_nl(input, &inputlen);
+	if (dup_input == NULL) {
+	    err(11, __func__, "dup_without_nl failed");
+	    not_reached();
+	}
+
+	/*
+	 * replace input with the duplicate w/o newline input if needed
+	 */
+	free(input);
+	input = dup_input;
+    }
+
+    /*
      * decode data read from input stream
      */
-    if (skip_eol_nl && inputlen > 0 && input[inputlen-1] == '\n') {
-	buf = json_decode(input, inputlen-1, &bufsiz);
-    } else {
-	buf = json_decode(input, inputlen, &bufsiz);
-    }
+    buf = json_decode(input, inputlen, &bufsiz);
     if (buf == NULL) {
 	/* free input */
 	if (input != NULL) {
@@ -270,18 +350,21 @@ main(int argc, char **argv)
     size_t outputlen;		/* length of write of decode buffer */
     bool success = true;	/* true ==> encoding OK, false ==> error while encoding */
     bool nloutput = true;	/* true ==> output newline after JSON decode */
-    bool skip_eol_nl = false;	/* true ==> ignore final newline when encoding */
+    bool ignore_nl = false;	/* true ==> ignore final newline when encoding */
     bool write_quote = false;	/* true ==> output enclosing quotes */
     bool esc_quotes = false;	/* true ==> escape quotes */
     int ret;			/* libc return code */
     int i;
+    int j;
+    int k;
     struct jstring *jstr = NULL;    /* decoded string */
+    char *dup_input = NULL;	/* duplicate of arg string */
 
     /*
      * set locale
      */
     if (setlocale(LC_ALL, "") == NULL) {
-	err(11, __func__, "failed to set locale");
+	err(12, __func__, "failed to set locale");
 	not_reached();
     }
 
@@ -329,7 +412,7 @@ main(int argc, char **argv)
 	    nloutput = false;
 	    break;
 	case 'N':
-	    skip_eol_nl = true;
+	    ignore_nl = true;
 	    break;
 	case 'Q':
 	    write_quote = true;
@@ -373,7 +456,7 @@ main(int argc, char **argv)
 		 * NOTE: the function jstrdecode_stream() adds the allocated
 		 * struct jstring * to the list of decoded JSON strings
 		 */
-		jstr = jstrdecode_stream(stdin, skip_eol_nl);
+		jstr = jstrdecode_stream(stdin, ignore_nl);
 		if (jstr != NULL) {
 		    dbg(DBG_MED, "decode length: %ju", jstr->bufsiz);
 		} else {
@@ -391,11 +474,28 @@ main(int argc, char **argv)
 		dbg(DBG_MED, "arg length: %ju", (uintmax_t)inputlen);
 
 		/*
+		 * If -N, and newlines in arg, remove them
+		 */
+		if (ignore_nl) {
+
+		    /*
+		     * copy input removing all newlines, update inputlen if needed
+		     */
+		    dup_input = dup_without_nl(input, &inputlen);
+		    if (dup_input == NULL) {
+			err(13, __func__, "dup_without_nl failed");
+			not_reached();
+		    }
+
+		    /*
+		     * replace input with the duplicate w/o newline input if needed
+		     */
+		    input = dup_input;
+		}
+
+		/*
 		 * decode arg
 		 */
-		if (skip_eol_nl && inputlen > 0 && input[inputlen-1] == '\n') {
-		    input[inputlen - 1] = '\0';
-		}
 		buf = json_decode_str(input, &bufsiz);
 		if (buf == NULL) {
 		    warn(__func__, "error while decoding processing arg: %d", i-optind);
@@ -414,6 +514,14 @@ main(int argc, char **argv)
 			dbg(DBG_MED, "added string of size %ju to decoded strings list", bufsiz);
 		    }
 		}
+
+		/*
+		 * free duplicated arg if -N
+		 */
+		if (ignore_nl) {
+		    free(input);
+		    input = NULL;
+		}
 	    }
 	}
 
@@ -426,7 +534,7 @@ main(int argc, char **argv)
 	 * NOTE: the function jstrdecode_stream() adds the allocated
 	 * struct jstring * to the list of decoded JSON strings
 	 */
-	jstr = jstrdecode_stream(stdin, skip_eol_nl);
+	jstr = jstrdecode_stream(stdin, ignore_nl);
 
 	if (jstr != NULL) {
 	    dbg(DBG_MED, "decode length: %ju", jstr->bufsiz);

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrdecode version
  */
-#define JSTRDECODE_VERSION "1.2.2 2024-10-10"	/* format: major.minor YYYY-MM-DD */
+#define JSTRDECODE_VERSION "1.2.3 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/man/man1/jstrdecode.1
+++ b/man/man1/jstrdecode.1
@@ -71,7 +71,7 @@ Run tests on the JSON decode/encode functions
 Do not output a newline after the decode function
 .TP
 .B \-N
-Skip final newline in input, for easier typing commands.
+Ignore and skip over all newlines input, for easier typing commands.
 .TP
 .B \-Q
 Enclose output in double quotes


### PR DESCRIPTION
We improve `jstrdecode -N` by ignoring all newlines in data.

Sequenced exit codes in `json_parse.c`.

Changed JSTRDECODE_VERSION from "1.2.2 2024-10-10" to "1.2.3 2024-10-10".

Performed `make release` to test the above under macOS.