### PR TITLE
improve -N for jstrencode, update man pages

### DIFF
--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -350,7 +350,7 @@ main(int argc, char **argv)
     size_t outputlen;		/* length of write of decode buffer */
     bool success = true;	/* true ==> encoding OK, false ==> error while encoding */
     bool nloutput = true;	/* true ==> output newline after JSON decode */
-    bool ignore_nl = false;	/* true ==> ignore final newline when encoding */
+    bool ignore_nl = false;	/* true ==> ignore all newlines when encoding */
     bool write_quote = false;	/* true ==> output enclosing quotes */
     bool esc_quotes = false;	/* true ==> escape quotes */
     int ret;			/* libc return code */
@@ -489,6 +489,8 @@ main(int argc, char **argv)
 		     * replace input with the duplicate w/o newline input if needed
 		     */
 		    input = dup_input;
+		    dbg(DBG_VHIGH, "-N and arg is now: %d: <%s>", i-optind, input);
+		    dbg(DBG_VHIGH, "-N and arg length is now: %ju", (uintmax_t)inputlen);
 		}
 
 		/*
@@ -516,7 +518,7 @@ main(int argc, char **argv)
 		/*
 		 * free duplicated arg if -N
 		 */
-		if (ignore_nl) {
+		if (ignore_nl && input != NULL) {
 		    free(input);
 		    input = NULL;
 		}

--- a/jstrencode.h
+++ b/jstrencode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrencode version
  */
-#define JSTRENCODE_VERSION "1.2.2 2024-10-10"	/* format: major.minor YYYY-MM-DD */
+#define JSTRENCODE_VERSION "1.2.3 2024-10-10"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/man/man1/jstrdecode.1
+++ b/man/man1/jstrdecode.1
@@ -71,7 +71,7 @@ Run tests on the JSON decode/encode functions
 Do not output a newline after the decode function
 .TP
 .B \-N
-Ignore and skip over all newlines input, for easier typing commands.
+Ignore and skip over all newlines, for easier typing commands.
 .TP
 .B \-Q
 Enclose output in double quotes

--- a/man/man1/jstrencode.1
+++ b/man/man1/jstrencode.1
@@ -58,7 +58,7 @@ Run tests on the JSON encode/encode functions
 Do not output a newline after the encode function
 .TP
 .B \-N
-Ignore trailing newline in input
+Ignore and skip over all newlines, for easier typing commands.
 .TP
 .B \-Q
 Do not encode double quotes that enclose the concatenation of args (def: do encode)


### PR DESCRIPTION
We improve `jstrencode -N` by ignoring all newlines in data.

Minor change to `jstrencode` as well.

Changed JSTRENCODE_VERSION from "1.2.2 2024-10-10" to "1.2.3 2024-10-10".

Performed `make release` to test the above under macOS.