### PR TITLE
fix an issue that causes make release to fail in the "other repo"

### DIFF
--- a/util.c
+++ b/util.c
@@ -38,7 +38,11 @@
  * dbg - info, debug, warning, error, and usage message facility
  */
 #if defined(INTERNAL_INCLUDE)
-#include "../dbg/dbg.h"
+# if defined(UTIL_TEST)
+# include "../../dbg/dbg.h"
+# else
+# include "../dbg/dbg.h"
+# endif
 #else
 #include <dbg.h>
 #endif


### PR DESCRIPTION
We fix when ../util.c is copied to util_test.c so that `make release` will work in the "other repo".