### PR TITLE
release 2.1.2 2024-11-16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 # Significant changes in the JSON parser repo
 
+
+## Release 2.1.2 2024-11-16
+
+The `-e` for `jstrencode(1)`, only encloses each decoded arg in escaped
+double quotes when there are multiple args.  If there is only one arg,
+no escaped double quotes are added.
+
+The usage message for `-Q` and `-e` for `jstrencode(1)` has been clarified
+as well as being in sync with the above mentioned `-e` change.
+
+The new version of each of the tools `jstrencode(1)` and `jstrdecode(1)` is
+`"2.1.2 2024-11-16"`  and the library is `"2.1.0 2024-11-15"`.
+
+Improved `test_jparse/jstr_test.sh` to show, when some tests fail,
+showing what was expected vs the result found when what was expected
+was a simple string (and not a file).
+
+Added new tests to `test_jparse/jstr_test.sh` as per the above
+changes to `jstrencode(1)`.
+
+Updated `jstrencode(1)` man page according to the above.
+
+The new version of `test_jparse/jstr_test.sh` is now "1.2.3 2024-11-16".
+
+
 ## Release 2.1.1 2024-11-16
 
 Use `date` rather than `/bin/date` in `jparse_bug_report.sh`.

--- a/jstrdecode.c
+++ b/jstrdecode.c
@@ -56,7 +56,7 @@ static const char * const usage_msg =
     "\t-n\t\tdo not output newline after decode output\n"
     "\t-N\t\tignore all newline characters in input\n"
     "\t-Q\t\tenclose output in double quotes (def: do not)\n"
-    "\t-e\t\tenclose each decoded string with escaped double quotes (def: do not)\n"
+    "\t-e\t\tfor multiple args, enclose each decoded arg in escaped double quotes (def: do not)\n"
     "\t-d\t\tdo not require a leading and trailing double quote (def: do require)\n"
     "\t-E level\tentertainment mode\n"
     "\n"
@@ -423,6 +423,9 @@ main(int argc, char **argv)
 	    break;
 	}
     }
+    dbg(DBG_LOW, "argc: %d", argc);
+    dbg(DBG_LOW, "optind: %d", optind);
+    dbg(DBG_LOW, "arg count: %d", argc - optind);
     dbg(DBG_LOW, "enclose in quotes: %s", booltostr(write_quote));
     dbg(DBG_LOW, "newline output: %s", booltostr(nloutput));
     dbg(DBG_LOW, "silence warnings: %s", booltostr(msg_warn_silent));
@@ -561,7 +564,7 @@ main(int argc, char **argv)
 	/*
 	 * write starting escaped quote if requested
 	 */
-	if (esc_quotes) {
+	if (esc_quotes && argc - optind > 1) {
 	    fprint(stdout, "%s", "\\\"");
 	}
 	buf = jstr->jstr;
@@ -578,7 +581,7 @@ main(int argc, char **argv)
 	/*
 	 * write ending escaped quote if requested
 	 */
-	if (esc_quotes) {
+	if (esc_quotes && argc - optind > 1) {
 	    fprint(stdout, "%s", "\\\"");
 	}
     }

--- a/jstrdecode.h
+++ b/jstrdecode.h
@@ -69,7 +69,7 @@
 /*
  * official jstrdecode version
  */
-#define JSTRDECODE_VERSION "2.1.1 2024-11-15"	/* format: major.minor YYYY-MM-DD */
+#define JSTRDECODE_VERSION "2.1.2 2024-11-16"	/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/man/man1/jstrdecode.1
+++ b/man/man1/jstrdecode.1
@@ -9,7 +9,7 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH jstrdecode 1 "15 November 2024" "jstrdecode" "jparse tools"
+.TH jstrdecode 1 "16 November 2024" "jstrdecode" "jparse tools"
 .SH NAME
 .B jstrdecode
 \- JSON decode command line strings
@@ -47,7 +47,8 @@ If given the
 option it will enclose the entire output in quotes.
 If given the
 .B \-e
-option it will enclose each decoded string with escaped double quotes.
+option it will enclose each decoded string with escaped double quotes,
+if and only if more than one string arg is given on the command line.
 The use of
 .B \-Q
 and
@@ -100,7 +101,8 @@ Ignore all newline characters in input
 Enclose output in double quotes
 .TP
 .B \-e
-Enclose each encoded string (after decoding) with escaped double quotes (def: do not)
+Enclose each encoded string (after decoding) with escaped double quotes (def: do not),
+if any only if more than one string is given on the command line.
 .TP
 .B \-d
 Don't require input to be surrounded by double quotes ("s).

--- a/test_jparse/jstr_test.sh
+++ b/test_jparse/jstr_test.sh
@@ -24,7 +24,7 @@ export JSTRENCODE="./jstrencode"
 export TEST_FILE="./test_jparse/jstr_test.out"
 export TEST_FILE2="./test_jparse/jstr_test2.out"
 export JSTR_TEST_TXT="./test_jparse/jstr_test.txt"
-export JSTR_TEST_VERSION="1.2.2 2024-11-13" # version format: major.minor YYYY-MM-DD
+export JSTR_TEST_VERSION="1.2.3 2024-11-16" # version format: major.minor YYYY-MM-DD
 export TOPDIR=
 
 export USAGE="usage: $0 [-h] [-V] [-v level] [-e jstrencode] [-d jstrdecode] [-Z topdir]
@@ -281,31 +281,40 @@ fi
 
 echo "$0: about to run test #4" 1>&2
 echo "$JSTRDECODE -d -Q -n foo bar"
+EXPECTED='"foobar"'
 RESULT="$($JSTRDECODE -d -Q -n foo bar)"
-if [[ "$RESULT" = '"foobar"' ]]; then
+if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #4 passed" 1>&2
 else
     echo "$0: test #4 failed" 1>&2
+    echo "$0: test #4 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #4 RESULT: $RESULT" 1>&2
     EXIT_CODE=4
 fi
 
 echo "$0: about to run test #5" 1>&2
 echo "$JSTRDECODE -d -Q -e -n foo bar"
+EXPECTED='"\"foo\"\"bar\""'
 RESULT="$($JSTRDECODE -d -Q -e -n foo bar)"
-if [[ "$RESULT" = '"\"foo\"\"bar\""' ]]; then
+if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #5 passed" 1>&2
 else
     echo "$0: test #5 failed" 1>&2
+    echo "$0: test #5 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #5 RESULT: $RESULT" 1>&2
     EXIT_CODE=4
 fi
 
 echo "$0: about to run test #6" 1>&2
 echo "$JSTRDECODE -d -e -n foo bar"
+EXPECTED='\"foo\"\"bar\"'
 RESULT="$($JSTRDECODE -d -e -n foo bar)"
-if [[ "$RESULT" = '\"foo\"\"bar\"' ]]; then
+if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #6 passed" 1>&2
 else
     echo "$0: test #6 failed" 1>&2
+    echo "$0: test #6 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #6 RESULT: $RESULT" 1>&2
     EXIT_CODE=4
 fi
 
@@ -321,11 +330,14 @@ fi
 
 echo "$0: about to run test #8" 1>&2
 echo "$JSTRDECODE" "$("$JSTRENCODE" '\\u0153\\u00df\\u00e5\\u00e9')" 1>&2
+EXPECTED="\\u0153\\u00df\\u00e5\\u00e9"
 RESULT=$("$JSTRDECODE" "$("$JSTRENCODE" '\u0153\u00df\u00e5\u00e9')")
-if [[ "$RESULT" = "\\u0153\\u00df\\u00e5\\u00e9" ]]; then
+if [[ "$RESULT" = "$EXPECTED" ]]; then
     echo "$0: test #8 passed" 1>&2
 else
     echo "$0: test #8 failed: result: $RESULT" 1>&2
+    echo "$0: test #8 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #8 RESULT: $RESULT" 1>&2
     EXIT_CODE=4
 fi
 
@@ -336,6 +348,58 @@ if cmp "$JSTR_TEST_TXT" "$TEST_FILE"; then
     echo "$0: test #9 passed" 1>&2
 else
     echo "$0: test #9 failed: result: $RESULT" 1>&2
+    EXIT_CODE=4
+fi
+
+echo "$0: about to run test #10" 1>&2
+echo "$JSTRDECODE -d -n foo bar"
+EXPECTED='foobar'
+RESULT="$($JSTRDECODE -d -n foo bar)"
+if [[ "$RESULT" = "$EXPECTED" ]]; then
+    echo "$0: test #10 passed" 1>&2
+else
+    echo "$0: test #10 failed" 1>&2
+    echo "$0: test #10 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #10 RESULT: $RESULT" 1>&2
+    EXIT_CODE=4
+fi
+
+echo "$0: about to run test #11" 1>&2
+echo "$JSTRDECODE -d -Q -n foo"
+EXPECTED='"foo"'
+RESULT="$($JSTRDECODE -d -Q -n foo)"
+if [[ "$RESULT" = "$EXPECTED" ]]; then
+    echo "$0: test #11 passed" 1>&2
+else
+    echo "$0: test #11 failed" 1>&2
+    echo "$0: test #11 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #11 RESULT: $RESULT" 1>&2
+    EXIT_CODE=4
+fi
+
+echo "$0: about to run test #12" 1>&2
+echo "$JSTRDECODE -d -Q -e -n foo"
+EXPECTED='"foo"'
+RESULT="$($JSTRDECODE -d -Q -e -n foo)"
+if [[ "$RESULT" = "$EXPECTED" ]]; then
+    echo "$0: test #12 passed" 1>&2
+else
+    echo "$0: test #12 failed" 1>&2
+    echo "$0: test #12 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #12 RESULT: $RESULT" 1>&2
+    EXIT_CODE=4
+fi
+
+echo "$0: about to run test #13" 1>&2
+echo "$JSTRDECODE -d -e -n foo"
+EXPECTED='foo'
+RESULT="$($JSTRDECODE -d -e -n foo)"
+if [[ "$RESULT" = "$EXPECTED" ]]; then
+    echo "$0: test #13 passed" 1>&2
+else
+    echo "$0: test #13 failed" 1>&2
+    echo "$0: test #13 EXPECTED: $EXPECTED"  1>&2
+    echo "$0: test #13 RESULT: $RESULT" 1>&2
     EXIT_CODE=4
 fi
 

--- a/version.h
+++ b/version.h
@@ -30,7 +30,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.1.1 2024-11-16"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.1.2 2024-11-16"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version


### PR DESCRIPTION
The following changes were made to the jparse tree:

The `-e` for `jstrencode(1)`, only encloses each decoded arg in escaped double quotes when there are multiple args.  If there is only one arg, no escaped double quotes are added.

The usage message for `-Q` and `-e` for `jstrencode(1)` has been clarified as well as being in sync with the above mentioned `-e` change.

The new version of each of the tools `jstrencode(1)` and `jstrdecode(1)` is `"2.1.2 2024-11-16"`  and the library is `"2.1.0 2024-11-15"`.

Improved `test_jparse/jstr_test.sh` to show, when some tests fail, showing what was expected vs the result found when what was expected was a simple string (and not a file).

Added new tests to `test_jparse/jstr_test.sh` as per the above changes to `jstrencode(1)`.

Updated `jstrencode(1)` man page according to the above.

The new version of `test_jparse/jstr_test.sh` is now "1.2.3 2024-11-16".

Performed `make release` to test the above under macOS.