### PR TITLE
increase debug message levels in jparse/util.c and jparse/verge.c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,14 @@ Changed `util.h` to include '<limits.h>` for the `CHAR_BIT` define,
 add code to define `CHAR_BIT` as 8 if undefined, and changed
 the `BITS_IN_BYTE` macro to use `CHAR_BIT` instead.
 
-Updated `JPARSE_UTILS_VERSION` to `"2.0.14 2025-08-30"`.
+Increased the debug level of most debug messages for functions in `jparse/verge.c`.
+In some cases a debug message was turned into a warning when an non-fatal
+error condition was detected.
 
-Increased the verbosity of debug messages for `vercmp()` in `verge.c`.
+Increased the debug level of non-UTIL_TEST code debug messages for
+functions in `jparse/util.c`.
+
+Updated `JPARSE_UTILS_VERSION` to `"2.0.15 2025-09-01"`.
 
 
 ## Release 2.2.47 2025-07-23

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ functions in `jparse/util.c`.
 
 Updated `JPARSE_UTILS_VERSION` to `"2.0.15 2025-09-01"`.
 
+The `test_jparse/Makefile` removes `test_jparse/util_test.o` for
+`make clean`, and removes `test_jparse/util_test.c` for `make clobber`.
+
 
 ## Release 2.2.47 2025-07-23
 

--- a/test_jparse/Makefile
+++ b/test_jparse/Makefile
@@ -655,6 +655,7 @@ clean:
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} ${RM_V} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
+	${Q} ${RM} ${RM_V} -f util_test.o
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -665,7 +666,7 @@ clobber: legacy_clobber clean
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
 	${Q} ${RM} ${RM_V} -f ${TARGETS}
-	${Q} ${RM} ${RM_V} -f jparse_test.log
+	${Q} ${RM} ${RM_V} -f jparse_test.log util_test.c
 	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
 	${Q} ${RM} ${RM_V} -rf a b
 	${S} echo

--- a/util.c
+++ b/util.c
@@ -452,7 +452,7 @@ dir_name(char const *path, int level)
                 not_reached();
             }
 
-            dbg(DBG_MED, "#4: dir_name(\"%s\", %d): %s", path, level, ret);
+            dbg(DBG_VHIGH, "#4: dir_name(\"%s\", %d): %s", path, level, ret);
             return ret;
         } else {
             /*
@@ -462,7 +462,7 @@ dir_name(char const *path, int level)
                 free(ret);
                 ret = NULL;
             }
-            dbg(DBG_MED, "#5: dir_name(\"%s\", %d): %s", path, level, copy);
+            dbg(DBG_VHIGH, "#5: dir_name(\"%s\", %d): %s", path, level, copy);
             return copy;
         }
     }
@@ -583,12 +583,12 @@ count_comps(char const *str, char comp, bool remove_all)
                 booltostr(remove_all));
 	return 0;
     }
-    dbg(DBG_HIGH, "#2: string before removing successive '%c's: %s", comp, copy);
 
     /*
      * remove any multiple trailing delimiter chars except the last one
      */
     if (remove_all) {
+	dbg(DBG_VHIGH, "#2: string before removing any multiple trailing delimiter chars '%c's: %s", comp, copy);
         for (i = len - 1; i > 0; --i) {
             if (copy[i] == comp) {
                 if (i > 0 && copy[i-1] != comp) {
@@ -2704,13 +2704,13 @@ find_path(char const *path, char *dir, int dirfd, int *cwd, bool abspath, struct
         not_reached();
     }
 
-    dbg(DBG_MED, "FTS_LOGICAL: %s", booltostr(fts->logical));
-    dbg(DBG_MED, "basename search: %s", booltostr(fts->base));
-    dbg(DBG_MED, "FTS_SEEDOT: %s", booltostr(fts->seedot));
-    dbg(DBG_MED, "case-sensitive: %s", booltostr(fts->match_case));
-    dbg(DBG_MED, "depth: %d", fts->depth);
-    dbg(DBG_MED, "count: %d", fts->count);
-    dbg(DBG_MED, "absolute path: %s", booltostr(abspath));
+    dbg(DBG_VHIGH, "FTS_LOGICAL: %s", booltostr(fts->logical));
+    dbg(DBG_VHIGH, "basename search: %s", booltostr(fts->base));
+    dbg(DBG_VHIGH, "FTS_SEEDOT: %s", booltostr(fts->seedot));
+    dbg(DBG_VHIGH, "case-sensitive: %s", booltostr(fts->match_case));
+    dbg(DBG_VHIGH, "depth: %d", fts->depth);
+    dbg(DBG_VHIGH, "count: %d", fts->count);
+    dbg(DBG_VHIGH, "absolute path: %s", booltostr(abspath));
 
 
     /*
@@ -2742,9 +2742,9 @@ find_path(char const *path, char *dir, int dirfd, int *cwd, bool abspath, struct
             if (*path == '\0') {
                 if (fts->count <= 0 || (fts->count > 0 && ++i == fts->count)) {
                     if (fts->count > 0) {
-                        dbg(DBG_MED, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
+                        dbg(DBG_HIGH, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
                     } else {
-                        dbg(DBG_MED, "found path %s at depth %d", p, fts->depth);
+                        dbg(DBG_HIGH, "found path %s at depth %d", p, fts->depth);
                     }
                     /*
                      * found a match: save found path
@@ -2789,9 +2789,9 @@ find_path(char const *path, char *dir, int dirfd, int *cwd, bool abspath, struct
                 (!fts->match_case && !strcasecmp(ent->fts_name, path)))) {
                     if (fts->count <= 0 || (fts->count > 0 && ++i == fts->count)) {
                         if (fts->count > 0) {
-                            dbg(DBG_MED, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
+                            dbg(DBG_HIGH, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
                         } else {
-                            dbg(DBG_MED, "found path %s at depth %d", p, fts->depth);
+                            dbg(DBG_HIGH, "found path %s at depth %d", p, fts->depth);
                         }
                         /*
                          * found a match, save path
@@ -2836,9 +2836,9 @@ find_path(char const *path, char *dir, int dirfd, int *cwd, bool abspath, struct
                          */
 
                         if (fts->count > 0) {
-                            dbg(DBG_MED, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
+                            dbg(DBG_HIGH, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
                         } else {
-                            dbg(DBG_MED, "found path %s at depth %d", p, fts->depth);
+                            dbg(DBG_HIGH, "found path %s at depth %d", p, fts->depth);
                         }
 
                         /*
@@ -3271,13 +3271,13 @@ find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd, bool abspath
     }
 
 
-    dbg(DBG_MED, "FTS_LOGICAL: %s", booltostr(fts->logical));
-    dbg(DBG_MED, "basename search: %s", booltostr(fts->base));
-    dbg(DBG_MED, "FTS_SEEDOT: %s", booltostr(fts->seedot));
-    dbg(DBG_MED, "case-sensitive: %s", booltostr(fts->match_case));
-    dbg(DBG_MED, "depth: %d", fts->depth);
-    dbg(DBG_MED, "count: %d", fts->count);
-    dbg(DBG_MED, "absolute path: %s", booltostr(abspath));
+    dbg(DBG_VHIGH, "FTS_LOGICAL: %s", booltostr(fts->logical));
+    dbg(DBG_VHIGH, "basename search: %s", booltostr(fts->base));
+    dbg(DBG_VHIGH, "FTS_SEEDOT: %s", booltostr(fts->seedot));
+    dbg(DBG_VHIGH, "case-sensitive: %s", booltostr(fts->match_case));
+    dbg(DBG_VHIGH, "depth: %d", fts->depth);
+    dbg(DBG_VHIGH, "count: %d", fts->count);
+    dbg(DBG_VHIGH, "absolute path: %s", booltostr(abspath));
 
     /*
      * first open the stream and get the first entry
@@ -3317,9 +3317,9 @@ find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd, bool abspath
                 if (*path == '\0') {
                     if (fts->count <= 0 || (fts->count > 0 && ++i == fts->count)) {
                         if (fts->count > 0) {
-                            dbg(DBG_MED, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
+                            dbg(DBG_HIGH, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
                         } else {
-                            dbg(DBG_MED, "found path %s at depth %d", p, fts->depth);
+                            dbg(DBG_HIGH, "found path %s at depth %d", p, fts->depth);
                         }
                         /*
                          * found a match
@@ -3374,9 +3374,9 @@ find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd, bool abspath
                          * found a match
                          */
                         if (fts->count > 0) {
-                            dbg(DBG_MED, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
+                            dbg(DBG_HIGH, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
                         } else {
-                            dbg(DBG_MED, "found path %s at depth %d", p, fts->depth);
+                            dbg(DBG_HIGH, "found path %s at depth %d", p, fts->depth);
                         }
 
                         name = NULL;
@@ -3429,9 +3429,9 @@ find_paths(struct dyn_array *paths, char *dir, int dirfd, int *cwd, bool abspath
                          */
 
                         if (fts->count > 0) {
-                            dbg(DBG_MED, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
+                            dbg(DBG_HIGH, "found path with count %d at depth %d: %s", fts->count, fts->depth, p);
                         } else {
-                            dbg(DBG_MED, "found path %s at depth %d", p, fts->depth);
+                            dbg(DBG_HIGH, "found path %s at depth %d", p, fts->depth);
                         }
 
                         name = NULL;
@@ -3990,7 +3990,7 @@ flush_tty(char const *name, bool flush_stdin, bool abort_on_error)
 		    errp(139, name, "fflush(stdin): error code: %d", ret);
 		    not_reached();
 		} else {
-		    dbg(DBG_MED, "%s: called via %s: fflush(stdin) failed: %s", __func__, name, strerror(errno));
+		    dbg(DBG_HIGH, "%s: called via %s: fflush(stdin) failed: %s", __func__, name, strerror(errno));
 		    return;
 		}
 	    }
@@ -4015,7 +4015,7 @@ flush_tty(char const *name, bool flush_stdin, bool abort_on_error)
 		errp(140, name, "fflush(stdout): error code: %d", ret);
 		not_reached();
 	    } else {
-		dbg(DBG_MED, "%s: called from %s: fflush(stdout) failed: %s", __func__, name, strerror(errno));
+		dbg(DBG_HIGH, "%s: called from %s: fflush(stdout) failed: %s", __func__, name, strerror(errno));
 		return;
 	    }
 	}
@@ -4039,7 +4039,7 @@ flush_tty(char const *name, bool flush_stdin, bool abort_on_error)
 		errp(141, name, "fflush(stderr): error code: %d", ret);
 		not_reached();
 	    } else {
-		dbg(DBG_MED, "%s: called from %s: fflush(stderr) failed: %s", __func__, name, strerror(errno));
+		dbg(DBG_HIGH, "%s: called from %s: fflush(stderr) failed: %s", __func__, name, strerror(errno));
 		return;
 	    }
 	}
@@ -4550,7 +4550,7 @@ resolve_path(char const *cmd)
             /*
              * str should be the command's path
              */
-            dbg(DBG_MED, "found executable file at: %s", str);
+            dbg(DBG_HIGH, "found executable file at: %s", str);
             /*
              * free dup
              */
@@ -4638,7 +4638,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
             err(150, __func__, "function name is not caller name because we were called with NULL name");
             not_reached();
         } else {
-            dbg(DBG_MED, "called with NULL name, returning: %d < 0", EXIT_NULL_ARGS);
+            warn(__func__, "called with NULL name, returning: %d < 0", EXIT_NULL_ARGS);
             return EXIT_NULL_ARGS;
         }
     }
@@ -4648,7 +4648,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
             err(151, name, "called with NULL format");
             not_reached();
         } else {
-            dbg(DBG_MED, "called with NULL format, returning: %d < 0", EXIT_NULL_ARGS);
+            warn(__func__, "called with NULL format, returning: %d < 0", EXIT_NULL_ARGS);
             return EXIT_NULL_ARGS;
         }
     }
@@ -4670,7 +4670,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
             errp(152, name, "calloc failed in vcmdprintf()");
             not_reached();
         } else {
-            dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s, returning: %d < 0",
+            warn(__func__, "called from %s: calloc failed in vcmdprintf(): %s, returning: %d < 0",
                          name, strerror(errno), EXIT_CALLOC_FAILED);
             va_end(ap);         /* stdarg variable argument list cleanup */
             errno = saved_errno;
@@ -4734,7 +4734,7 @@ shell_cmd(char const *name, bool flush_stdin, bool abort_on_error, char const *f
             not_reached();
         } else {
             saved_errno = errno;
-            dbg(DBG_MED, "called from %s: execution of the shell failed for system(\"%s\")", name, cmd);
+            warn(__func__, "called from %s: execution of the shell failed for system(\"%s\")", name, cmd);
             va_end(ap);         /* stdarg variable argument list cleanup */
             /* free allocated command storage */
             if (cmd != NULL) {
@@ -4806,7 +4806,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
 	    err(155, __func__, "function name is not caller name because we were called with NULL name");
 	    not_reached();
 	} else {
-	    dbg(DBG_MED, "called with NULL name, returning NULL");
+	    warn(__func__, "called with NULL name, returning NULL");
 	    return NULL;
 	}
     }
@@ -4816,7 +4816,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
 	    err(156, name, "called with NULL format");
 	    not_reached();
 	} else {
-	    dbg(DBG_MED, "called with NULL format, returning NULL");
+	    warn(__func__, "called with NULL format, returning NULL");
 	    return NULL;
 	}
     }
@@ -4837,7 +4837,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
 	    errp(157, name, "calloc failed in vcmdprintf()");
 	    not_reached();
 	} else {
-	    dbg(DBG_MED, "called from %s: calloc failed in vcmdprintf(): %s returning: %d < 0",
+	    warn(__func__, "called from %s: calloc failed in vcmdprintf(): %s returning: %d < 0",
 			 name, strerror(errno), EXIT_CALLOC_FAILED);
 	    va_end(ap);		/* stdarg variable argument list cleanup */
 	    return NULL;
@@ -4875,7 +4875,7 @@ pipe_open(char const *name, bool write_mode, bool abort_on_error, char const *fo
             not_reached();
         } else {
             saved_errno = errno;
-            dbg(DBG_MED, "called from %s: error calling popen(\"%s\", \"%s\"): %s", name, cmd, write_mode ? "w" : "r",
+            warn(__func__, "called from %s: error calling popen(\"%s\", \"%s\"): %s", name, cmd, write_mode ? "w" : "r",
                 strerror(errno));
             va_end(ap);        /* stdarg variable argument list cleanup */
             if (cmd != NULL) {
@@ -6074,7 +6074,7 @@ touch(char const *path, mode_t mode)
         not_reached();
     }
 
-    dbg(DBG_MED, "created file %s with mode %04o", path, mode);
+    dbg(DBG_HIGH, "created file %s with mode %04o", path, mode);
 
     /*
      * now close the file we created
@@ -6289,7 +6289,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
                 }
             }
         } else {
-            dbg(DBG_MED, "made directory: %s", dup);
+            dbg(DBG_HIGH, "made directory: %s", dup);
             /*
              * now set modes
              */
@@ -6327,7 +6327,7 @@ mkdirs(int dirfd, const char *str, mode_t mode)
                 }
             }
         } else {
-            dbg(DBG_MED, "made directory: %s", p);
+            dbg(DBG_HIGH, "made directory: %s", p);
             /*
              * now set modes
              */

--- a/verge.c
+++ b/verge.c
@@ -89,8 +89,8 @@ vercmp(char *ver1, char *ver2)
         err(56, __func__, "second version string is NULL or empty");
         not_reached();
     }
-    dbg(DBG_MED, "first version: <%s>", ver1);
-    dbg(DBG_MED, "second version: <%s>", ver2);
+    dbg(DBG_HIGH, "first version: <%s>", ver1);
+    dbg(DBG_HIGH, "second version: <%s>", ver2);
 
     /*
      * convert first version string
@@ -102,7 +102,7 @@ vercmp(char *ver1, char *ver2)
             free(vlevel1);
             vlevel1 = NULL;
         }
-	dbg(DBG_HIGH, "first version string is invalid");
+	warn(__func__, "first version string is invalid");
         return 4;
     }
 
@@ -121,7 +121,7 @@ vercmp(char *ver1, char *ver2)
             vlevel2 = NULL;
         }
 
-        dbg(DBG_HIGH, "second version string is invalid");
+        warn(__func__, "second version string is invalid");
         return 4;
     }
 
@@ -136,9 +136,9 @@ vercmp(char *ver1, char *ver2)
 	if (vlevel1[i] > vlevel2[i]) {
 
 	    /* ver1 > ver2 */
-	    dbg(DBG_HIGH, "version 1 level %d: %jd > version 2 level %d: %jd",
+	    dbg(DBG_VHIGH, "version 1 level %d: %jd > version 2 level %d: %jd",
 			  i, vlevel1[i], i, vlevel2[i]);
-	    dbg(DBG_MED, "%s > %s", ver1, ver2);
+	    dbg(DBG_HIGH, "%s > %s", ver1, ver2);
 	    /* free memory */
 	    if (vlevel1 != NULL) {
 		free(vlevel1);
@@ -153,9 +153,9 @@ vercmp(char *ver1, char *ver2)
 	} else if (vlevel1[i] < vlevel2[i]) {
 
 	    /* ver1 < ver2 */
-	    dbg(DBG_HIGH, "version 1 level %d: %jd < version 2 level %d: %jd",
+	    dbg(DBG_VHIGH, "version 1 level %d: %jd < version 2 level %d: %jd",
 			  i, vlevel1[i], i, vlevel2[i]);
-	    dbg(DBG_MED, "%s < %s", ver1, ver2);
+	    dbg(DBG_HIGH, "%s < %s", ver1, ver2);
 	    /* free memory */
 	    if (vlevel1 != NULL) {
 		free(vlevel1);
@@ -170,11 +170,11 @@ vercmp(char *ver1, char *ver2)
 	} else {
 
 	    /* versions match down to this level */
-	    dbg(DBG_HIGH, "version 1 level %d: %jd == version 2 level %d: %jd",
+	    dbg(DBG_VHIGH, "version 1 level %d: %jd == version 2 level %d: %jd",
 			  i, vlevel1[i], i, vlevel2[i]);
 	}
     }
-    dbg(DBG_HIGH, "versions match down to level: %d",
+    dbg(DBG_VHIGH, "versions match down to level: %d",
 		 (ver1_levels > ver2_levels) ? ver2_levels : ver1_levels);
 
     /*
@@ -196,16 +196,16 @@ vercmp(char *ver1, char *ver2)
      */
     if (ver1_levels < ver2_levels) {
 
-	dbg(DBG_HIGH, "version 1 level count: %d < version level count: %d",
+	dbg(DBG_VHIGH, "version 1 level count: %d < version level count: %d",
 		     ver1_levels, ver2_levels);
-	dbg(DBG_MED, "%s < %s", ver1, ver2);
+	dbg(DBG_HIGH, "%s < %s", ver1, ver2);
 	/* report ver1 < ver2 */
         return 1;
     } else if (ver1_levels > ver2_levels) {
 
-	dbg(DBG_HIGH, "version 1 level count: %d > version level count: %d",
+	dbg(DBG_VHIGH, "version 1 level count: %d > version level count: %d",
 		     ver1_levels, ver2_levels);
-	dbg(DBG_MED, "%s > %s", ver1, ver2);
+	dbg(DBG_HIGH, "%s > %s", ver1, ver2);
 	/* report ver1 > ver2 */
         return 0;
     }
@@ -213,9 +213,9 @@ vercmp(char *ver1, char *ver2)
     /*
      * versions match
      */
-    dbg(DBG_HIGH, "version 1 level count: %d == version level count: %d",
+    dbg(DBG_VHIGH, "version 1 level count: %d == version level count: %d",
 		 ver1_levels, ver2_levels);
-    dbg(DBG_MED, "%s == %s", ver1, ver2);
+    dbg(DBG_HIGH, "%s == %s", ver1, ver2);
     /* report ver1 == ver2 */
     return 0;
 }
@@ -255,7 +255,7 @@ allocate_vers(char *str, intmax_t **pvers)
     }
     len = strlen(str);
     if (len <= 0) {
-	dbg(DBG_MED, "version string is empty");
+	warn(__func__, "version string is empty");
 	return 0;
     }
 
@@ -281,7 +281,7 @@ allocate_vers(char *str, intmax_t **pvers)
     }
     if (i == len) {
 	/* report invalid version string */
-	dbg(DBG_MED, "version string contained no digits: <%s>", wstr);
+	warn(__func__, "version string contained no digits: <%s>", wstr);
 	/* free strdup()d string if != NULL */
 	if (wstr_start != NULL) {
 	    free(wstr_start);
@@ -321,14 +321,14 @@ allocate_vers(char *str, intmax_t **pvers)
      * Inspect the remaining string for digits and '.'s only.
      * Also reject string if we find more than 2 '.'s in a row.
      */
-    dbg(DBG_HIGH, "trimmed version string: <%s>", wstr);
+    dbg(DBG_VHIGH, "trimmed version string: <%s>", wstr);
     for (i=0; i < len; ++i) {
 	if (isascii(wstr[i]) && isdigit(wstr[i])) {
 	    dot = false;
 	} else if (wstr[i] == '.') {
 	    if (dot == true) {
 		/* report invalid version string */
-		dbg(DBG_MED, "trimmed version string contains 2 dots in a row: <%s>", wstr);
+		dbg(DBG_HIGH, "trimmed version string contains 2 dots in a row: <%s>", wstr);
 		/* free strdup()d string if != NULL */
 		if (wstr_start != NULL) {
 		    free(wstr_start);
@@ -340,7 +340,7 @@ allocate_vers(char *str, intmax_t **pvers)
 	    ++dot_count;
 	} else {
 	    /* report invalid version string */
-	    dbg(DBG_MED, "trimmed version string contains non-version character: wstr[%ju] = <%c>: <%s>",
+	    dbg(DBG_HIGH, "trimmed version string contains non-version character: wstr[%ju] = <%c>: <%s>",
 			 (uintmax_t)i, wstr[i], wstr);
 	    /* free strdup()d string if != NULL */
 	    if (wstr_start != NULL) {
@@ -350,8 +350,8 @@ allocate_vers(char *str, intmax_t **pvers)
 	    return 0;
 	}
     }
-    dbg(DBG_MED, "trimmed version string is valid format: <%s>", wstr);
-    dbg(DBG_HIGH, "trimmed version string has %ju '.'s in it: <%s>", (uintmax_t)dot_count, wstr);
+    dbg(DBG_HIGH, "trimmed version string is valid format: <%s>", wstr);
+    dbg(DBG_VHIGH, "trimmed version string has %ju '.'s in it: <%s>", (uintmax_t)dot_count, wstr);
 
     /*
      * we now know the version string is valid format: ([0-9]+\.)*[0-9]+
@@ -372,9 +372,9 @@ allocate_vers(char *str, intmax_t **pvers)
          i <= dot_count && word != NULL;
 	 ++i, word=strtok_r(NULL, ".", &brkt)) {
 	/* word is the next version string - convert to integer */
-	dbg(DBG_VVHIGH, "version level %ju word: <%s>", (uintmax_t)i, word);
+	dbg(DBG_VVVHIGH, "version level %ju word: <%s>", (uintmax_t)i, word);
 	(void) string_to_intmax(word, &(*pvers)[i]);
-	dbg(DBG_VHIGH, "version level %ju: %jd", (uintmax_t)i, (*pvers)[i]);
+	dbg(DBG_VVHIGH, "version level %ju: %jd", (uintmax_t)i, (*pvers)[i]);
     }
 
     /* we no longer need the duplicated string */

--- a/version.h
+++ b/version.h
@@ -70,7 +70,7 @@
 /*
  * official utility functions (util.c) version
  */
-#define JPARSE_UTILS_VERSION "2.0.14 2025-08-30"         /* format: major.minor YYYY-MM-DD */
+#define JPARSE_UTILS_VERSION "2.0.15 2025-09-01"         /* format: major.minor YYYY-MM-DD */
 
 
 #endif /* INCLUDE_JPARSE_VERSION_H */


### PR DESCRIPTION
Increased the debug level of most debug messages for functions in `jparse/verge.c`.

In some cases a debug message was turned into a warning when an non-fatal
error condition was detected.

Increased the debug level of non-UTIL_TEST code debug messages for
functions in `jparse/util.c`.

Updated `JPARSE_UTILS_VERSION` to `"2.0.15 2025-09-01"`.