### PR TITLE
use new `dyn_array_qsort(3)` function in jparse/jsemtblgen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Significant changes in the JSON parser repo
 
+## Release 2.3.1 2025-09-08
+
+Updated `jparse/jsemtblgen.c` to use the new `dyn_array_qsort(3)` function
+from [dyn_array repo](https://github.com/lcn2/dyn_array) "2.4.0 2024-09-08".
+
+Updated `JPARSE_REPO_VERSION` to "2.3.1 2025-09-08".
+Updated `JSEMTBLGEN_VERSION` to "2.0.3 2025-09-08".
+
+
 ## Release 2.3.0 2025-09-01
 
 Moved nearly all of the tree and file utility functions

--- a/jsemtblgen.c
+++ b/jsemtblgen.c
@@ -1040,7 +1040,7 @@ print_sem_c_src(struct dyn_array *tbl, char *tbl_name, char *cap_tbl_name)
     /*
      * sort the semantic table
      */
-    qsort(tbl->data, (size_t)dyn_array_tell(tbl), sizeof(struct json_sem), sem_cmp);
+    dyn_array_qsort(tbl, sem_cmp);
 
     /*
      * print semantic table header
@@ -1256,7 +1256,7 @@ print_sem_h_src(struct dyn_array *tbl, char *tbl_name, char *cap_tbl_name)
     /*
      * sort the semantic table
      */
-    qsort(tbl->data, (size_t)dyn_array_tell(tbl), sizeof(struct json_sem), sem_cmp);
+    dyn_array_qsort(tbl, sem_cmp);
 
     /*
      * allocate empty dynamic array of unique function names

--- a/jsemtblgen.h
+++ b/jsemtblgen.h
@@ -97,7 +97,7 @@
 /*
  * official jsemtblgen version
  */
-#define JSEMTBLGEN_VERSION "2.0.2 2025-06-26"		/* format: major.minor YYYY-MM-DD */
+#define JSEMTBLGEN_VERSION "2.0.3 2025-09-08"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * jsemtblgen tool basename

--- a/version.h
+++ b/version.h
@@ -55,7 +55,7 @@
  *
  * NOTE: this should match the latest Release string in CHANGES.md
  */
-#define JPARSE_REPO_VERSION "2.3.0 2025-09-01"		/* format: major.minor YYYY-MM-DD */
+#define JPARSE_REPO_VERSION "2.3.1 2025-09-08"		/* format: major.minor YYYY-MM-DD */
 
 /*
  * official jparse version


### PR DESCRIPTION
Updated `jparse/jsemtblgen.c` to use the new `dyn_array_qsort(3)` function.

**NOTE**: This requires installing `DYN_ARRAY_VERSION` "2.4.0 2024-09-08" from he [dyn_array repo](https://github.com/lcn2/dyn_array).

Updated `JPARSE_REPO_VERSION` to "2.3.1 2025-09-08". Updated `JSEMTBLGEN_VERSION` to "2.0.3 2025-09-08".

Ran `make release` to test the above.