### PR TITLE
improve on pr 1321

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,14 @@ Changed `MAX_BYTE` to have `ULL` (i.e. change it to unsigned long long).
 
 Fix various old format strings in several files.
 
+Improved `make depend` to not produce needless "`../`" in the dependencies.
+
+Improved how `BITS_IN_BYTE`, `BYTE_VALUES`, and `MAX_BYTE` are defined.
+
+With the exception of printing Unicode Control Point hex values,
+regularized to debug, warning and error messages to use lower case hex,
+with a leading 0x, and to be consistent with how "the repo" does this.
+
 Updated `JPARSE_LIBRARY_VERSION` to `"2.4.3 2025-10-02"`.
 Updated `JPARSE_UTILS_VERSION` to `"2.1.5 2025-10-02"`.
 Updated `JPARSE_TOOL_VERSION` to `"2.0.3 2025-10-02"`.

--- a/Makefile
+++ b/Makefile
@@ -1309,7 +1309,14 @@ depend: ${ALL_CSRC}
 	    fi; \
 	    ${SED} -i.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
-	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
+	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' \
+			-e 's;\.\./pr/\.\./dyn_array/;../dyn_array/;g' \
+			-e 's;\.\./pr/\.\./dbg/;../dbg/;g' \
+			-e 's;\.\./dyn_array/\.\./dbg/;../dbg/;g' \
+			-e 's;\.\./jparse/\.\./pr/;../pr/;g' \
+			-e 's;\.\./jparse/\.\./dyn_array/;../dyn_array/;g' \
+			-e 's;\.\./jparse/\.\./dbg/;../dbg/;g' \
+			| \
 	      ${INDEPEND} -v ${VERBOSITY} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} ${RM_V} -f Makefile.orig; \

--- a/jparse.l
+++ b/jparse.l
@@ -319,7 +319,7 @@ JSON_COMMA		","
 			    /*
                              * invalid token: any other character (regexp ".")
                              */
-			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02X = <%c>", yylloc->first_line,
+			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line,
                                     yylloc->first_column, *yytext, *yytext);
 
 			    /*
@@ -545,7 +545,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
 	     * case: below the report limit
 	     */
 	    if (*low_bytes <= MAX_LOW_BYTES_REPORTED) {
-		werr(36, __func__, "invalid LOW byte 0x%02X detected in line: %zu byte position: %zu",
+		werr(36, __func__, "invalid LOW byte 0x%02x detected in line: %zu byte position: %zu",
 			 data[i], linenum, byte_pos);
 
 	    /*

--- a/jparse.ref.c
+++ b/jparse.ref.c
@@ -1451,7 +1451,7 @@ YY_RULE_SETUP
 			    /*
                              * invalid token: any other character (regexp ".")
                              */
-			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02X = <%c>", yylloc->first_line,
+			    dbg(DBG_LOW, "at line %d column %d: invalid token: 0x%02x = <%c>", yylloc->first_line,
                                     yylloc->first_column, *yytext, *yytext);
 
 			    /*
@@ -2845,7 +2845,7 @@ low_byte_scan(char const *data, size_t len, size_t *low_bytes, size_t *nul_bytes
 	     * case: below the report limit
 	     */
 	    if (*low_bytes <= MAX_LOW_BYTES_REPORTED) {
-		werr(36, __func__, "invalid LOW byte 0x%02X detected in line: %zu byte position: %zu",
+		werr(36, __func__, "invalid LOW byte 0x%02x detected in line: %zu byte position: %zu",
 			 data[i], linenum, byte_pos);
 
 	    /*

--- a/json_parse.c
+++ b/json_parse.c
@@ -943,7 +943,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (byte2asciistr[i].byte != i) {
-	    err(174, __func__, "byte2asciistr[0x%02X].byte: %d != %d", i, byte2asciistr[i].byte, i);
+	    err(174, __func__, "byte2asciistr[0x%02x].byte: %d != %d", i, byte2asciistr[i].byte, i);
 	    not_reached();
 	}
     }
@@ -953,7 +953,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (byte2asciistr[i].enc == NULL) {
-	    err(175, __func__, "byte2asciistr[0x%02X].enc == NULL", i);
+	    err(175, __func__, "byte2asciistr[0x%02x].enc == NULL", i);
 	    not_reached();
 	}
     }
@@ -963,7 +963,7 @@ chkbyte2asciistr(void)
      */
     for (i=0; i < JSON_BYTE_VALUES; ++i) {
 	if (strlen(byte2asciistr[i].enc) != byte2asciistr[i].len) {
-	    err(176, __func__, "byte2asciistr[0x%02X].enc length: %zu != byte2asciistr[0x%02X].len: %zu",
+	    err(176, __func__, "byte2asciistr[0x%02x].enc length: %zu != byte2asciistr[0x%02x].len: %zu",
 			       i, strlen(byte2asciistr[i].enc),
 			       i, byte2asciistr[i].len);
 	    not_reached();
@@ -975,18 +975,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x00; i <= 0x07; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(177, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	    err(177, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			       i, strlen(byte2asciistr[i].enc),
 			       LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(178, __func__, "byte2asciistr[0x%02X].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(178, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(179, __func__, "byte2asciistr[0x%02X].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(179, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -997,13 +997,13 @@ chkbyte2asciistr(void)
     indx = 0x08;
     encstr = "\\b";
     if (byte2asciistr[indx].len != LITLEN("\\b")) {
-	err(180, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(180, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(181, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(181, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1013,13 +1013,13 @@ chkbyte2asciistr(void)
     indx = 0x09;
     encstr = "\\t";
     if (byte2asciistr[indx].len != LITLEN("\\b")) {
-	err(182, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(182, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(183, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(183, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1029,13 +1029,13 @@ chkbyte2asciistr(void)
     indx = 0x0a;
     encstr = "\\n";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(184, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(184, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(185, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(185, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1045,13 +1045,13 @@ chkbyte2asciistr(void)
     indx = 0x0b;
     encstr = "\\u000b";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(186, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(186, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(187, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(187, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1061,13 +1061,13 @@ chkbyte2asciistr(void)
     indx = 0x0c;
     encstr = "\\f";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(188, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(188, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(189, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(189, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1077,13 +1077,13 @@ chkbyte2asciistr(void)
     indx = 0x0d;
     encstr = "\\r";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(190, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(190, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(191, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(191, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1092,18 +1092,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x0e; i <= 0x1f; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(192, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	    err(192, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			       i, strlen(byte2asciistr[i].enc),
 			       LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(193, __func__, "byte2asciistr[0x%02X].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(193, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(194, __func__, "byte2asciistr[0x%02X].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(194, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -1113,12 +1113,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x20; i <= 0x21; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(195, __func__, "byte2asciistr[0x%02X].enc length: %zu != %d",
+	    err(195, __func__, "byte2asciistr[0x%02x].enc length: %zu != %d",
 			       i, strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(196, __func__, "byte2asciistr[0x%02X].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(196, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -1129,13 +1129,13 @@ chkbyte2asciistr(void)
     indx = 0x22;
     encstr = "\\\"";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(197, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(197, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(198, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(198, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1144,12 +1144,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x23; i <= 0x5b; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(199, __func__, "byte2asciistr[0x%02X].enc length: %zu != %d",
+	    err(199, __func__, "byte2asciistr[0x%02x].enc length: %zu != %d",
 			       i, strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(200, __func__, "byte2asciistr[0x%02X].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(200, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -1160,13 +1160,13 @@ chkbyte2asciistr(void)
     indx = 0x5c;
     encstr = "\\\\";
     if (byte2asciistr[indx].len != strlen(encstr)) {
-	err(201, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	err(201, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			   indx, strlen(byte2asciistr[indx].enc),
 			   strlen(encstr));
 	not_reached();
     }
     if (strcmp(byte2asciistr[indx].enc, encstr) != 0) {
-	err(202, __func__, "byte2asciistr[0x%02X].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
+	err(202, __func__, "byte2asciistr[0x%02x].enc: <%s> != <%s>", indx, byte2asciistr[indx].enc, encstr);
 	not_reached();
     }
 
@@ -1175,12 +1175,12 @@ chkbyte2asciistr(void)
      */
     for (i=0x5d; i <= 0x7e; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(203, __func__, "byte2asciistr[0x%02X].enc length: %zu != %d",
+	    err(203, __func__, "byte2asciistr[0x%02x].enc length: %zu != %d",
 			       i, strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((unsigned int)(byte2asciistr[i].enc[0]) != i) {
-	    err(204, __func__, "byte2asciistr[0x%02X].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
+	    err(204, __func__, "byte2asciistr[0x%02x].enc: <%s> is not <%c>", i, byte2asciistr[i].enc, (char)i);
 	    not_reached();
 	}
     }
@@ -1190,18 +1190,18 @@ chkbyte2asciistr(void)
      */
     for (i=0x7f; i <= 0x7f; ++i) {
 	if (byte2asciistr[i].len != LITLEN("\\uxxxx")) {
-	    err(205, __func__, "byte2asciistr[0x%02X].enc length: %zu != %zu",
+	    err(205, __func__, "byte2asciistr[0x%02x].enc length: %zu != %zu",
 			       i, strlen(byte2asciistr[i].enc),
 			       LITLEN("\\uxxxx"));
 	    not_reached();
 	}
 	ret = sscanf(byte2asciistr[i].enc, "\\u%04x%c", &int_hexval, &guard);
 	if (ret != 1) {
-	    err(206, __func__, "byte2asciistr[0x%02X].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
+	    err(206, __func__, "byte2asciistr[0x%02x].enc: <%s> is not in <\\uxxxx> form", i, byte2asciistr[i].enc);
 	    not_reached();
 	}
 	if (i != int_hexval) {
-	    err(207, __func__, "byte2asciistr[0x%02X].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
+	    err(207, __func__, "byte2asciistr[0x%02x].enc: <%s> != <\\u%04x> form", i, byte2asciistr[i].enc, i);
 	    not_reached();
 	}
     }
@@ -1211,17 +1211,17 @@ chkbyte2asciistr(void)
      */
     for (i=0x80; i <= 0xff; ++i) {
 	if (byte2asciistr[i].len != 1) {
-	    err(208, __func__, "byte2asciistr[0x%02X].enc length: %zu != %d",
+	    err(208, __func__, "byte2asciistr[0x%02x].enc length: %zu != %d",
 			       i, strlen(byte2asciistr[i].enc), 1);
 	    not_reached();
 	}
 	if ((uint8_t)(byte2asciistr[i].enc[0]) != i) {
-	    err(209, __func__, "byte2asciistr[0x%02X].enc[0]: 0x%02X is not 0x%02jx",
+	    err(209, __func__, "byte2asciistr[0x%02x].enc[0]: 0x%02x is not 0x%02jx",
 			       i, (uint8_t)(byte2asciistr[i].enc[0]) & 0xff, (uintmax_t)i);
 	    not_reached();
 	}
 	if ((uint8_t)(byte2asciistr[i].enc[1]) != 0) {
-	    err(210, __func__, "byte2asciistr[0x%02X].enc[1]: 0x%02X is not 0",
+	    err(210, __func__, "byte2asciistr[0x%02x].enc[1]: 0x%02x is not 0",
 			       i, (uint8_t)(byte2asciistr[i].enc[1]) & 0xff);
 	    not_reached();
 	}
@@ -1261,28 +1261,28 @@ chkbyte2asciistr(void)
 	/*
 	 * test JSON encoding
 	 */
-	dbg(DBG_VVVHIGH, "testing json_encode_str(0x%02X, *mlen)", i);
+	dbg(DBG_VVVHIGH, "testing json_encode_str(0x%02x, *mlen)", i);
 	/* load input string */
 	str[0] = (char)i;
 	/* test json_encode_str() */
 	mstr = json_encode_str(str, &mlen, false);
 	/* check encoding result */
 	if (mstr == NULL) {
-	    err(214, __func__, "json_encode_str(0x%02X, *mlen: %zu) == NULL",
+	    err(214, __func__, "json_encode_str(0x%02x, *mlen: %zu) == NULL",
 			       i, mlen);
 	    not_reached();
 	}
 	if (mlen != byte2asciistr[i].len) {
-	    err(215, __func__, "json_encode_str(0x%02X, *mlen %zu != %zu)",
+	    err(215, __func__, "json_encode_str(0x%02x, *mlen %zu != %zu)",
 			       i, mlen, byte2asciistr[i].len);
 	    not_reached();
 	}
 	if (strcmp(byte2asciistr[i].enc, mstr) != 0) {
-	    err(216, __func__, "json_encode_str(0x%02X, *mlen: %zu) != <%s>", i,
+	    err(216, __func__, "json_encode_str(0x%02x, *mlen: %zu) != <%s>", i,
 			       mlen, byte2asciistr[i].enc);
 	    not_reached();
 	}
-	dbg(DBG_VVHIGH, "testing json_encode_str(0x%02X, *mlen) encoded to <%s>", i, mstr);
+	dbg(DBG_VVHIGH, "testing json_encode_str(0x%02x, *mlen) encoded to <%s>", i, mstr);
 
 	/*
 	 * test decoding the JSON encoded string
@@ -1301,7 +1301,7 @@ chkbyte2asciistr(void)
 	    not_reached();
 	}
 	if ((uint8_t)(mstr2[0]) != i) {
-	    err(219, __func__, "json_decode_str(<%s>, false, *mlen2: %zu): 0x%02X != 0x%02X",
+	    err(219, __func__, "json_decode_str(<%s>, false, *mlen2: %zu): 0x%02x != 0x%02x",
 			       mstr, mlen2, (uint8_t)(mstr2[0]) & 0xff, i);
 	    not_reached();
 	}
@@ -1623,7 +1623,7 @@ decode_json_string(char const *ptr, size_t len, size_t mlen, size_t *retlen)
 		    ret = NULL;
 		}
 
-		warn(__func__, "found invalid JSON \\-escape while decoding: followed by 0x%02X", (uint8_t)c);
+		warn(__func__, "found invalid JSON \\-escape while decoding: followed by 0x%02x", (uint8_t)c);
 		return NULL;
 	    }
 	}
@@ -1745,7 +1745,7 @@ json_decode(char const *ptr, size_t len, bool quote, size_t *retlen)
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
-		warn(__func__, "found non-\\-escaped char: 0x%02X", (uint8_t)c);
+		warn(__func__, "found non-\\-escaped char: 0x%02x", (uint8_t)c);
 		return NULL;
 		break;
 
@@ -1891,7 +1891,7 @@ json_decode(char const *ptr, size_t len, bool quote, size_t *retlen)
 		if (retlen != NULL) {
 		    *retlen = 0;
 		}
-		warn(__func__, "found invalid JSON \\-escape: followed by 0x%02X", (uint8_t)c);
+		warn(__func__, "found invalid JSON \\-escape: followed by 0x%02x", (uint8_t)c);
 		return NULL;
 	    }
 	}
@@ -2557,7 +2557,7 @@ json_process_decimal(struct json_number *item, char const *str, size_t len)
 	return false;	/* processing failed */
     }
     if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
-	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02X for str: %s", len, (int)str[len-1], str);
+	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
     str_len = strlen(str);
@@ -2896,7 +2896,7 @@ json_process_floating(struct json_number *item, char const *str, size_t len)
 	return false;	/* processing failed */
     }
     if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
-	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02X for str: %s", len, (int)str[len-1], str);
+	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
     str_len = strlen(str);
@@ -3519,7 +3519,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	 */
 	if (str[0] == '/') {
 	    *slash = true;
-	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is /: 0x%02X", (unsigned int)str[0]);
+	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is /: 0x%02x", (unsigned int)str[0]);
 
 	/*
 	 * case: first character is alphanumeric
@@ -3528,16 +3528,16 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	    *first_alphanum = true;
 	    if (isupper(str[0])) {
 		*upper = true;
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is UPPER CASE: 0x%02X", (unsigned int)str[0]);
+		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is UPPER CASE: 0x%02x", (unsigned int)str[0]);
 	    } else {
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is alphanumeric: 0x%02X", (unsigned int)str[0]);
+		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is alphanumeric: 0x%02x", (unsigned int)str[0]);
 	    }
 
 	/*
 	 * case: first character is non-alphanumeric portable POSIX safe plus +
 	 */
 	} else if (str[0] == '.' || str[0] == '_' || str[0] == '+') {
-	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is ASCII non-alphanumeric POSIX portable safe plus +: 0x%02X",
+	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is ASCII non-alphanumeric POSIX portable safe plus +: 0x%02x",
 			     (unsigned int)str[0]);
 
 	/*
@@ -3545,7 +3545,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	 */
 	} else {
 	    found_unsafe = true;
-	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is not POSIX portable safe plus +/: 0x%02X",
+	    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is not POSIX portable safe plus +/: 0x%02x",
 			     (unsigned int)str[0]);
 	}
 
@@ -3554,7 +3554,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
      */
     } else {
 	found_unsafe = true;
-	dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is non-ASCII: 0x%02X",
+	dbg(DBG_VVVHIGH, "posix_safe_chk(): str[0] is non-ASCII: 0x%02x",
 			 (unsigned int)str[0]);
     }
 
@@ -3573,7 +3573,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	     */
 	    if (str[i] == '/') {
 		if (*slash == false) {
-		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first / at str[%zu]: 0x%02X",
+		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first / at str[%zu]: 0x%02x",
 				     i, (unsigned int)str[i]);
 		}
 		*slash = true;
@@ -3583,7 +3583,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	     */
 	    } else if (isalnum(str[i])) {
 		if (*upper == false && isupper(str[i])) {
-		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first UPPER CASE at str[%zu]: 0x%02X",
+		    dbg(DBG_VVVHIGH, "posix_safe_chk(): found first UPPER CASE at str[%zu]: 0x%02x",
 				     i, (unsigned int)str[i]);
 		    *upper = true;
 		}
@@ -3593,7 +3593,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	     */
 	    } else if (str[i] != '.' && str[i] != '_' && str[i] != '+' && str[i] != '-') {
 		if (found_unsafe == false) {
-		    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%zu] found first non-POSIX portable safe plus +/: 0x%02X",
+		    dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%zu] found first non-POSIX portable safe plus +/: 0x%02x",
 				     i, (unsigned int)str[i]);
 		}
 		found_unsafe = true;
@@ -3604,7 +3604,7 @@ posix_safe_chk(char const *str, size_t len, bool *slash, bool *posix_safe, bool 
 	 */
 	} else {
 	    if (found_unsafe == false) {
-		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%zu] found first non-ASCII: 0x%02X",
+		dbg(DBG_VVVHIGH, "posix_safe_chk(): str[%zu] found first non-ASCII: 0x%02x",
 				 i, (unsigned int)str[i]);
 	    }
 	    found_unsafe = true;

--- a/json_sem.c
+++ b/json_sem.c
@@ -1680,7 +1680,7 @@ sem_object_find_name(struct json const *node, unsigned int depth, struct json_se
 	}
 	if (s->type != JTYPE_MEMBER) {
 	    if (val_err != NULL) {
-		*val_err = werr_sem_val(85, node, depth+1, sem, name, "JTYPE_OBJECT set[%d] type: %s != JTYPE_MEMBER",
+		*val_err = werr_sem_val(85, node, depth+1, sem, name, "JTYPE_OBJECT set[%jd] type: %s != JTYPE_MEMBER",
 					i, json_type_name(s->type));
 	    }
 	    return NULL;

--- a/json_utf8.c
+++ b/json_utf8.c
@@ -77,18 +77,18 @@ utf8len(const char *str, int32_t surrogate)
 	x = surrogate;
 	if (x < 0x80) {
 	    len = 1;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else if (x < 0x800) {
 	    len = 2;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else if (x < 0x10000) {
 	    len = 3;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else if (x < 0x110000) {
 	    len = 4;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else {
-	    warn(__func__, "%X: illegal value, len: %zd\n", x, len);
+	    warn(__func__, "0x%x illegal value, len: %zd\n", x, len);
 	    len = -1;
 	}
 
@@ -134,18 +134,18 @@ utf8len(const char *str, int32_t surrogate)
 	 */
 	if (x < 0x80) {
 	    len = 1;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else if (x < 0x800) {
 	    len = 2;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else if (x < 0x10000) {
 	    len = 3;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else if (x < 0x110000) {
 	    len = 4;
-	    dbg(DBG_VVHIGH, "%X length %zd", x, len);
+	    dbg(DBG_VVHIGH, "0x%x length %zd", x, len);
 	} else {
-	    warn(__func__, "%X: illegal value, len %zd\n", x, len);
+	    warn(__func__, "0x%x illegal value, len %zd\n", x, len);
 	    len = -1;
 	}
     }
@@ -181,10 +181,10 @@ surrogate_pair_to_codepoint(int32_t hi, int32_t lo)
      * These should theoretically never happen.
      */
     if (hi < 0) {
-        warn(__func__, "high byte < 0: 0x%4X", hi);
+        warn(__func__, "high byte < 0: 0x%04x", hi);
         return -1;
     } else if (lo < 0) {
-        warn(__func__, "low byte < 0: 0x%4X", lo);
+        warn(__func__, "low byte < 0: 0x%04x", lo);
         return -1;
     }
 
@@ -280,26 +280,26 @@ codepoint_to_unicode(char *output, unsigned int codepoint)
     }
 
     if (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
-	warn(__func__, "codepoint: %X: illegal surrogate", codepoint);
+	warn(__func__, "codepoint: 0x%x: illegal surrogate", codepoint);
 	len = -2;
     } else if (codepoint <= 0x7F) {
         output[0] = (char)codepoint;
         output[1] = '\0';
         len = 1;
-        dbg(DBG_VVHIGH, "%s: codepoint: %X <= 0x7F", __func__, codepoint);
+        dbg(DBG_VVHIGH, "%s: codepoint: 0x%x <= 0x7F", __func__, codepoint);
     } else if (codepoint <= 0x7FF) {
         output[0] = (char)(0xC0 | (codepoint >> 6));
         output[1] = (char)(0x80 | (codepoint & 0x3F));
         output[2] = '\0';
         len = 2;
-        dbg(DBG_VVHIGH, "%s: codepoint: %X <= 0x7FF", __func__, codepoint);
+        dbg(DBG_VVHIGH, "%s: codepoint: 0x%x <= 0x7FF", __func__, codepoint);
     } else if (codepoint <= 0xFFFF) {
         output[0] = (char)(0xE0 | (codepoint >> 12));
         output[1] = (char)(0x80 | ((codepoint >> 6) & 0x3F));
         output[2] = (char)(0x80 | (codepoint & 0x3F));
         output[3] = '\0';
         len = 3;
-        dbg(DBG_VVHIGH, "%s: codepoint: %X <= 0xFFFF", __func__, codepoint);
+        dbg(DBG_VVHIGH, "%s: codepoint: 0x%x <= 0xFFFF", __func__, codepoint);
     } else if (codepoint <= 0x10FFFF) {
         output[0] = (char)(0xF0 | (codepoint >> 18));
         output[1] = (char)(0x80 | ((codepoint >> 12) & 0x3F));
@@ -307,7 +307,7 @@ codepoint_to_unicode(char *output, unsigned int codepoint)
         output[3] = (char)(0x80 | (codepoint & 0x3F));
         output[4] = '\0';
         len = 4;
-        dbg(DBG_VVHIGH, "%s: codepoint: %X <= 0x10FFFF", __func__, codepoint);
+        dbg(DBG_VVHIGH, "%s: codepoint: 0x%x <= 0x10FFFF", __func__, codepoint);
     } else {
 	warn(__func__, "illegal value: %#X too big\n", codepoint);
 	len = -1;
@@ -384,10 +384,10 @@ is_surrogate_pair(const int32_t xa, const int32_t xb)
         return false;
     }
     if (xa >= 0xD800 && xa <= 0xDBFF && xb >= 0xDC00 && xb <= 0xDFFF) {
-        dbg(DBG_HIGH, "high surrogate 0x%4X followed by low surrogate 0x%4X", xa, xb);
+        dbg(DBG_HIGH, "high surrogate 0x%04x followed by low surrogate 0x%04x", xa, xb);
         return true;
     } else if (xa >= 0xDC00 && xa <= 0xDFFF) {
-        warn(__func__, "low surrogate 0x%4X not preceded by high surrogate", xa);
+        warn(__func__, "low surrogate 0x%04x not preceded by high surrogate", xa);
         return false;
     }
     return false;

--- a/test_jparse/Makefile
+++ b/test_jparse/Makefile
@@ -749,8 +749,14 @@ depend: ${ALL_CSRC}
 	    fi; \
 	    ${SED} -i\.orig -n -e '1,/^### DO NOT CHANGE MANUALLY BEYOND THIS LINE$$/p' Makefile; \
 	    ${CC} ${CFLAGS} -MM -I. ${ALL_CSRC} | \
-	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
-	      ${SED} -e 's;../../jparse/;../;g' | \
+	      ${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' \
+			-e 's;\.\./\.\./pr/\.\./dyn_array/;../../dyn_array/;g' \
+			-e 's;\.\./\.\./pr/\.\./dbg/;../../dbg/;g' \
+			-e 's;\.\./\.\./dyn_array/\.\./dbg/;../../dbg/;g' \
+			-e 's;\.\./\.\./jparse/\.\./pr/;../../pr/;g' \
+			-e 's;\.\./\.\./jparse/\.\./dyn_array/;../../dyn_array/;g' \
+			-e 's;\.\./\.\./jparse/\.\./dbg/;../../dbg/;g' \
+			| \
 	      ${INDEPEND} -v ${VERBOSITY} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
 		${RM} ${RM_V} -f Makefile.orig; \

--- a/util.c
+++ b/util.c
@@ -451,7 +451,7 @@ is_floating_notation(char const *str, size_t len)
     }
 
     if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
-	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02X for str: %s", len, (int)str[len-1], str);
+	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
 
@@ -602,7 +602,7 @@ is_e_notation(char const *str, size_t len)
     }
 
     if (!isascii(str[len-1]) || !isdigit(str[len-1])) {
-	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02X for str: %s", len, (int)str[len-1], str);
+	warn(__func__, "str[%zu-1] is not an ASCII digit: 0x%02x for str: %s", len, (int)str[len-1], str);
 	return false;	/* processing failed */
     }
 

--- a/util.h
+++ b/util.h
@@ -95,11 +95,17 @@
  * byte as octet constants
  */
 #if !defined(CHAR_BIT)
-# define CHAR_BIT (8)		/* paranoia - in case limits.h is very old */
+ #define CHAR_BIT (8)		/* paranoia - in case limits.h is very old */
 #endif
-#define BITS_IN_BYTE (CHAR_BIT)	    /* assume 8 bit bytes */
-#define MAX_BYTE (0xFFULL)	    /* maximum byte value */
-#define BYTE_VALUES (MAX_BYTE+1)    /* number of different combinations of bytes */
+#if !defined(BITS_IN_BYTE)
+ #define BITS_IN_BYTE (CHAR_BIT)	    /* assume 8 bit bytes */
+#endif
+#if !defined(BYTE_VALUES)
+ #define BYTE_VALUES (1<<CHAR_BIT)   /* number of different combinations of bytes */
+#endif
+#if !defined(MAX_BYTE)
+ #define MAX_BYTE (BYTE_VALUES-1)    /* maximum byte value */
+#endif
 
 /*
  * off_t MAX and MIN


### PR DESCRIPTION
Improved `make depend` to not produce needless "`../`" in the dependencies.

Improved how `BITS_IN_BYTE`, `BYTE_VALUES`, and `MAX_BYTE` are defined.

With the exception of printing Unicode Control Point hex values, regularized to debug, warning and error messages to use lower case hex, with a leading 0x, and to be consistent with how "the repo" does this.

Ran `make release` to test the above.