### PR TITLE
sort tags using the C locale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1133,7 +1133,7 @@ all_tags:
 		${SED} -e 's;\t;\t'$${dir}'/;' "$${dir}/${LOCAL_DIR_TAGS}" >> tags; \
 	    fi; \
 	done
-	${E} ${SORT} tags -o tags
+	${E} LC_ALL="C" LANG="C" ${SORT} tags -o tags
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/test_jparse/Makefile
+++ b/test_jparse/Makefile
@@ -636,7 +636,7 @@ all_tags:
 		${SED} -e 's;\t;\t'$${dir}'/;' "$${dir}/${LOCAL_DIR_TAGS}" >> tags; \
 	    fi; \
 	done
-	${E} ${SORT} tags -o tags
+	${E} LC_ALL="C" LANG="C" ${SORT} tags -o tags
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 


### PR DESCRIPTION
The `make tags` rule sorts with `LC_ALL="C" LANG="C"`.

**NOTE**: This is a change to `make tags` only.  No API was changed.

Ran `make release` to test the above.