### PR TITLE
fix .gitignore, update codeql-action to v4.37.4 as per GitHub bump

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
 
     # Initialises the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.3
+      uses: github/codeql-action/init@v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -78,6 +78,6 @@ jobs:
        sudo make install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.3
+      uses: github/codeql-action/analyze@v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 ._.DS_Store
 *.dSYM/
 foobar
-/.github
 /jfmt
 /jnamval
 /jparse


### PR DESCRIPTION
Removed `.github` from `.gitignore`.

Updated update codeql-action to v4.37.4 as per GitHub bump